### PR TITLE
Lock pyvista version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -35,7 +35,7 @@ dependencies:
   - mne
   - https://github.com/numpy/numpydoc/archive/master.zip
   - imageio-ffmpeg>=0.4.1
-  - pyvista>=0.24
+  - pyvista==0.24
   - mayavi
   - PySurfer[save_movie]
   - dipy --only-binary dipy


### PR DESCRIPTION
Pull request #104 threw the TravisCI error below even though I did not change any code in the area.

```bash
../../../../miniconda/lib/python3.7/site-packages/mne-0.20.5-py3.7.egg/mne/viz/backends/_pyvista.py:73: in build    
plotter = self.plotter_class(**self.store)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <pyvista.plotting.BackgroundPlotter object at 0x7fa2ec618510>, args = ()
kwargs = {'auto_update': False, 'border': False, 'off_screen': False, 'shape': (1, 1), ...}
    def __init__(self, *args, **kwargs):
        """Empty init."""

>       raise QtDeprecationError('BackgroundPlotter')
E       pyvista.plotting.QtDeprecationError: `BackgroundPlotter` has moved to pyvistaqt.
E           You can install this from PyPI with: `pip install pyvistaqt`
E           See https://github.com/pyvista/pyvistaqt
```

This seems to be pyvista related so I have locked the version to 0.24