### PR TITLE
Rename roi_picks to picks_pair_to_idx

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -97,4 +97,4 @@ Channels
 
    get_short_channels
    get_long_channels
-   roi_picks
+   picks_pair_to_idx

--- a/examples/plot_20_cui.py
+++ b/examples/plot_20_cui.py
@@ -30,7 +30,7 @@ import matplotlib.pyplot as plt
 
 import mne
 import mne_nirs
-from mne_nirs.channels import roi_picks
+from mne_nirs.channels import picks_pair_to_idx
 
 
 ###############################################################################
@@ -144,8 +144,8 @@ left_sd_pairs = [[1, 1], [1, 2], [1, 3], [2, 1], [2, 3],
 right_sd_pairs = [[5, 5], [5, 6], [5, 7], [6, 5], [6, 7],
                   [6, 8], [7, 6], [7, 7], [8, 7], [8, 8]]
 
-groups = dict(Left_ROI=roi_picks(raw_anti.pick(picks='hbo'), left_sd_pairs),
-              Right_ROI=roi_picks(raw_anti.pick(picks='hbo'), right_sd_pairs))
+groups = dict(Left_ROI=picks_pair_to_idx(raw_anti.pick(picks='hbo'), left_sd_pairs),
+              Right_ROI=picks_pair_to_idx(raw_anti.pick(picks='hbo'), right_sd_pairs))
 
 
 ###############################################################################

--- a/examples/plot_20_cui.py
+++ b/examples/plot_20_cui.py
@@ -139,13 +139,13 @@ for column, condition in enumerate(['Original Data', 'Cui Enhanced Data']):
 # Plot the epoch image for each approach. First we specify the source
 # detector pairs for analysis.
 
-left_sd_pairs = [[1, 1], [1, 2], [1, 3], [2, 1], [2, 3],
-                 [2, 4], [3, 2], [3, 3], [4, 3], [4, 4]]
-right_sd_pairs = [[5, 5], [5, 6], [5, 7], [6, 5], [6, 7],
-                  [6, 8], [7, 6], [7, 7], [8, 7], [8, 8]]
+left = [[1, 1], [1, 2], [1, 3], [2, 1], [2, 3],
+        [2, 4], [3, 2], [3, 3], [4, 3], [4, 4]]
+right = [[5, 5], [5, 6], [5, 7], [6, 5], [6, 7],
+         [6, 8], [7, 6], [7, 7], [8, 7], [8, 8]]
 
-groups = dict(Left_ROI=picks_pair_to_idx(raw_anti.pick(picks='hbo'), left_sd_pairs),
-              Right_ROI=picks_pair_to_idx(raw_anti.pick(picks='hbo'), right_sd_pairs))
+groups = dict(Left_ROI=picks_pair_to_idx(raw_anti.pick(picks='hbo'), left),
+              Right_ROI=picks_pair_to_idx(raw_anti.pick(picks='hbo'), right))
 
 
 ###############################################################################

--- a/mne_nirs/channels/__init__.py
+++ b/mne_nirs/channels/__init__.py
@@ -5,4 +5,4 @@
 # License: BSD (3-clause)
 
 from ._short import get_short_channels, get_long_channels
-from ._roi import roi_picks
+from ._roi import picks_pair_to_idx

--- a/mne_nirs/channels/_roi.py
+++ b/mne_nirs/channels/_roi.py
@@ -7,7 +7,7 @@ import numpy as np
 from mne.utils import warn
 
 
-def roi_picks(raw, sd_pairs, on_missing='error'):
+def picks_pair_to_idx(raw, sd_pairs, on_missing='error'):
     """
     Return a list of picks for specified source detector pairs.
 

--- a/mne_nirs/channels/tests/test_roi.py
+++ b/mne_nirs/channels/tests/test_roi.py
@@ -40,7 +40,9 @@ def test_roi_picks():
     assert len(picks) == 6
 
     # Test usage for ROI downstream functions
-    group_by = dict(Left_ROI=picks_pair_to_idx(raw, [[1, 1], [1, 2], [5, 13]]),
-                    Right_ROI=picks_pair_to_idx(raw, [[3, 3], [3, 11], [6, 8]]))
+    group_by = dict(Left_ROI=picks_pair_to_idx(raw, [[1, 1], [1, 2],
+                                                     [5, 13]]),
+                    Right_ROI=picks_pair_to_idx(raw, [[3, 3], [3, 11],
+                                                      [6, 8]]))
     assert group_by['Left_ROI'] == [0, 1, 2, 3, 34, 35]
     assert group_by['Right_ROI'] == [18, 19, 20, 21, 40, 41]

--- a/mne_nirs/channels/tests/test_roi.py
+++ b/mne_nirs/channels/tests/test_roi.py
@@ -6,7 +6,7 @@
 import os
 import mne
 import pytest
-from mne_nirs.channels import roi_picks
+from mne_nirs.channels import picks_pair_to_idx
 
 
 def test_roi_picks():
@@ -14,7 +14,7 @@ def test_roi_picks():
     fnirs_raw_dir = os.path.join(fnirs_data_folder, 'Participant-1')
     raw = mne.io.read_raw_nirx(fnirs_raw_dir).load_data()
 
-    picks = roi_picks(raw, [[1, 1], [1, 2], [5, 13], [8, 16]])
+    picks = picks_pair_to_idx(raw, [[1, 1], [1, 2], [5, 13], [8, 16]])
 
     assert raw.ch_names[picks[0]] == "S1_D1 760"
     assert raw.ch_names[picks[1]] == "S1_D1 850"
@@ -29,18 +29,18 @@ def test_roi_picks():
     assert raw.ch_names[picks[7]] == "S8_D16 850"
 
     with pytest.raises(ValueError, match='No matching'):
-        roi_picks(raw, [[1, 1], [1, 2], [15, 13], [8, 16]])
+        picks_pair_to_idx(raw, [[1, 1], [1, 2], [15, 13], [8, 16]])
 
-    roi_picks(raw, [[1, 1], [1, 2], [15, 13], [8, 16]],
-              on_missing='warning')
+    picks_pair_to_idx(raw, [[1, 1], [1, 2], [15, 13], [8, 16]],
+                      on_missing='warning')
 
-    picks = roi_picks(raw, [[1, 1], [1, 2], [15, 13], [8, 16]],
-                      on_missing='ignore')
+    picks = picks_pair_to_idx(raw, [[1, 1], [1, 2], [15, 13], [8, 16]],
+                              on_missing='ignore')
 
     assert len(picks) == 6
 
     # Test usage for ROI downstream functions
-    group_by = dict(Left_ROI=roi_picks(raw, [[1, 1], [1, 2], [5, 13]]),
-                    Right_ROI=roi_picks(raw, [[3, 3], [3, 11], [6, 8]]))
+    group_by = dict(Left_ROI=picks_pair_to_idx(raw, [[1, 1], [1, 2], [5, 13]]),
+                    Right_ROI=picks_pair_to_idx(raw, [[3, 3], [3, 11], [6, 8]]))
     assert group_by['Left_ROI'] == [0, 1, 2, 3, 34, 35]
     assert group_by['Right_ROI'] == [18, 19, 20, 21, 40, 41]


### PR DESCRIPTION
This naming seems more consistent with existing MNE functions such as...

_picks_str_to_idx https://github.com/mne-tools/mne-python/blob/98b0bb332076ca49b40abde0856cee169a9ed94e/mne/io/pick.py#L1024

