### PR TITLE
MAINT: Faster build plus memory usage

### DIFF
--- a/.github/workflows/SphinxBuild.yml
+++ b/.github/workflows/SphinxBuild.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "doc/"
-        pre-build-command: "apt-get update -y && apt-get install -y python3-psutil"
+        pre-build-command: "apt-get update -y && apt-get install -y python3-psutil && pip install memory_profiler"
     # Publish built docs to gh-pages branch.
     # ===============================
     - name: Commit documentation changes

--- a/.github/workflows/SphinxBuild.yml
+++ b/.github/workflows/SphinxBuild.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "doc/"
-        pre-build-command: "apt-get update -y && apt-get install python3-dev build-essential && pip install memory_profiler"
+        pre-build-command: "apt-get update -y && apt-get install -y python3-dev build-essential"
     # Publish built docs to gh-pages branch.
     # ===============================
     - name: Commit documentation changes

--- a/.github/workflows/SphinxBuild.yml
+++ b/.github/workflows/SphinxBuild.yml
@@ -15,13 +15,14 @@ jobs:
     - shell: bash -el {0}
       run: |
         cp requirements_doc.txt doc/requirements.txt
+        sudo apt-get install python3-dev build-essential
+        pip install psutil
     - shell: bash -el {0}
       run: |
         git clone --depth 1 https://github.com/rob-luke/BIDS-NIRS-Tapping.git examples/BIDS-NIRS-Tapping
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "doc/"
-        pre-build-command: "apt-get update -y && apt-get install -y python3-psutil && pip install memory_profiler"
     # Publish built docs to gh-pages branch.
     # ===============================
     - name: Commit documentation changes

--- a/.github/workflows/SphinxBuild.yml
+++ b/.github/workflows/SphinxBuild.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "doc/"
+        pre-build-command: "apt-get update -y && apt-get install -y python3-psutil"
     # Publish built docs to gh-pages branch.
     # ===============================
     - name: Commit documentation changes

--- a/.github/workflows/SphinxBuild.yml
+++ b/.github/workflows/SphinxBuild.yml
@@ -15,14 +15,13 @@ jobs:
     - shell: bash -el {0}
       run: |
         cp requirements_doc.txt doc/requirements.txt
-        sudo apt-get install python3-dev build-essential
-        pip install psutil
     - shell: bash -el {0}
       run: |
         git clone --depth 1 https://github.com/rob-luke/BIDS-NIRS-Tapping.git examples/BIDS-NIRS-Tapping
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "doc/"
+        pre-build-command: "apt-get update -y && apt-get install python3-dev build-essential && pip install memory_profiler"
     # Publish built docs to gh-pages branch.
     # ===============================
     - name: Commit documentation changes

--- a/.github/workflows/SphinxBuild_PR.yml
+++ b/.github/workflows/SphinxBuild_PR.yml
@@ -10,13 +10,14 @@ jobs:
     - shell: bash -el {0}
       run: |
         cp requirements_doc.txt doc/requirements.txt
+        sudo apt-get install python3-dev build-essential
+        pip install psutil
     - shell: bash -el {0}
       run: |
         git clone --depth 1 https://github.com/rob-luke/BIDS-NIRS-Tapping.git examples/BIDS-NIRS-Tapping
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "doc/"
-        pre-build-command: "apt-get update -y && apt-get install -y python3-psutil && pip install memory_profiler"
     - uses: actions/upload-artifact@v1
       with:
         name: DocumentationHTML

--- a/.github/workflows/SphinxBuild_PR.yml
+++ b/.github/workflows/SphinxBuild_PR.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "doc/"
-        pre-build-command: "apt-get update -y && apt-get install python3-dev build-essential && pip install memory_profiler"
+        pre-build-command: "apt-get update -y && apt-get install -y python3-dev build-essential"
     - uses: actions/upload-artifact@v1
       with:
         name: DocumentationHTML

--- a/.github/workflows/SphinxBuild_PR.yml
+++ b/.github/workflows/SphinxBuild_PR.yml
@@ -10,14 +10,13 @@ jobs:
     - shell: bash -el {0}
       run: |
         cp requirements_doc.txt doc/requirements.txt
-        sudo apt-get install python3-dev build-essential
-        pip install psutil
     - shell: bash -el {0}
       run: |
         git clone --depth 1 https://github.com/rob-luke/BIDS-NIRS-Tapping.git examples/BIDS-NIRS-Tapping
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "doc/"
+        pre-build-command: "apt-get update -y && apt-get install python3-dev build-essential && pip install memory_profiler"
     - uses: actions/upload-artifact@v1
       with:
         name: DocumentationHTML

--- a/.github/workflows/SphinxBuild_PR.yml
+++ b/.github/workflows/SphinxBuild_PR.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "doc/"
-        pre-build-command: "apt-get update -y && apt-get install -y python3-psutil"
+        pre-build-command: "apt-get update -y && apt-get install -y python3-psutil && pip install memory_profiler"
     - uses: actions/upload-artifact@v1
       with:
         name: DocumentationHTML

--- a/.github/workflows/SphinxBuild_PR.yml
+++ b/.github/workflows/SphinxBuild_PR.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "doc/"
+        pre-build-command: "apt-get update -y && apt-get install -y python3-psutil"
     - uses: actions/upload-artifact@v1
       with:
         name: DocumentationHTML

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -329,7 +329,7 @@ sphinx_gallery_conf = {
     'reference_url': {
         'mne_nirs': None},
     'download_all_examples': False,
-    'show_memory': False,
+    'show_memory': True,
 }
 
 

--- a/examples/plot_12_group_glm.py
+++ b/examples/plot_12_group_glm.py
@@ -107,6 +107,11 @@ LetsPlot.setup_html()
 # We return the raw object and data frames for the computed results.
 # Information about channels, triggers and their meanings are stored in the
 # BIDS structure and are automatically obtained when importing the data.
+#
+# Here we also resample to a 0.3 Hz sample rate just to speed up the example
+# and use less memory, resampling to 0.6 Hz is a better choice for full
+# analyses.
+
 
 def individual_analysis(bids_path, ID):
 
@@ -115,7 +120,7 @@ def individual_analysis(bids_path, ID):
     # Convert signal to haemoglobin and resample
     raw_od = optical_density(raw_intensity)
     raw_haemo = beer_lambert_law(raw_od)
-    raw_haemo.resample(0.6)
+    raw_haemo.resample(0.3)
 
     # Cut out just the short channels for creating a GLM repressor
     sht_chans = get_short_channels(raw_haemo)

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -12,6 +12,7 @@ mne>=0.21.0
 https://codeload.github.com/larsoner/sphinx-bootstrap-divs/zip/master
 https://codeload.github.com/rob-luke/mne-bids/zip/nirs
 lets-plot
+memory_profiler
 statsmodels
 Ipython
 lxml


### PR DESCRIPTION
`mprof run plot_12_group_glm.py` followed by `mprof plot` produces:

![Figure_1](https://user-images.githubusercontent.com/2365790/95689604-edca4200-0bdf-11eb-9c36-de4a8b736db8.png)

Adding `memory_profilier` to your CircleCI build will tell you how much memory examples use. This PR does that, and tweaks the example to use a bit less memory.

Event dropping from 0.6 to 0.5 took it down from ~1.5GB to ~1.2GB, so if that's a better solution feel free to push that change and use it.