### PR TITLE
WIP: Run example scripts in pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ target/
 # System files
 ***.DS_Store
 **.idea
+
+# Generated files
+***.snirf

--- a/mne_nirs/tests/test_notebooks.py
+++ b/mne_nirs/tests/test_notebooks.py
@@ -1,0 +1,29 @@
+# Authors: Robert Luke <mail@robertluke.net>
+#
+# License: BSD (3-clause)
+
+# This script runs each of the example scripts. It acts as a system test.
+
+import os
+import pytest
+
+
+def examples_path():
+    test_file_path = os.path.dirname(os.path.abspath(__file__))
+    return test_file_path + "/../../examples/"
+
+
+def run_script_and_check(test_file_path):
+    return os.popen(f"python3 {test_file_path} && echo 'success'").read()
+
+@pytest.mark.parametrize('fname', (["plot_10_hrf_simulation.py",
+                                    "plot_11_hrf_measured.py",
+                                    "plot_12_group_glm.py",
+                                    "plot_19_snirf.py",
+                                    "plot_20_enhance.py",
+                                    "plot_30_frequency.py",
+                                    "plot_99_bad.py"]))
+def test_hrf_simulation(fname):
+    test_file_path = examples_path() + fname
+    assert "success" in run_script_and_check(test_file_path)
+


### PR DESCRIPTION
This test ensures the example scripts all run without error. This is slightly redundant as there is a seperate CI to build these in to html, but this allows me to run pytest locally and catch everything in one run. If I start to hit CI limits then this can be disabled. Starts to address #190, next step is to tidy up the module tests.