### PR TITLE
Use nilearn master due to numpy issue

### DIFF
--- a/examples/plot_19_snirf.py
+++ b/examples/plot_19_snirf.py
@@ -36,7 +36,6 @@ from mne_nirs.io import write_raw_snirf
 from numpy.testing import assert_allclose
 
 
-
 ###############################################################################
 # Import raw NIRS data from vendor
 # --------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ vtk<8.2; platform_system == "Darwin"
 vtk; platform_system != "Darwin"
 https://github.com/enthought/mayavi/archive/master.zip
 PySurfer[save_movie]
-nilearn>=0.7.0
+https://github.com/nilearn/nilearn/archive/master.zip # due to https://github.com/nilearn/nilearn/pull/2638
 xlrd
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1


### PR DESCRIPTION
The documentation is not building and throwing the following error

```python
  File "/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/nilearn/signal.py", line 20, in <module>
116
    NP_VERSION = distutils.version.LooseVersion(np.version.short_version).version
117
AttributeError: module 'numpy.version' has no attribute 'short_version'
```

which seems related to https://github.com/nilearn/nilearn/pull/2638, so I will bump nilearn to master