### PR TITLE
BUG: Use correct trigger times if signal is cropped

### DIFF
--- a/mne_nirs/experimental_design/_experimental_design.py
+++ b/mne_nirs/experimental_design/_experimental_design.py
@@ -69,7 +69,7 @@ def make_first_level_design_matrix(raw, stim_dur=1.,
 
     # Create events for nilearn
     conditions = raw.annotations.description
-    onsets = raw.annotations.onset
+    onsets = raw.annotations.onset - raw.first_time
     duration = stim_dur * np.ones(len(conditions))
     events = DataFrame({'trial_type': conditions,
                         'onset': onsets,


### PR DESCRIPTION
The onset times used in the design matrix did not match the signal if the data had previously been cropped.