### PR TITLE
ENH: Allow OLS in addition to mixedlm

### DIFF
--- a/mne_nirs/statistics/_statsmodels.py
+++ b/mne_nirs/statistics/_statsmodels.py
@@ -38,10 +38,11 @@ def expand_summary_dataframe(summary):
 
     summary = summary.copy()  # Copies required to suppress .loc warnings
     sum_copy = summary.copy(deep=True)
-    float_p = [float(p) for p in sum_copy["P>|z|"]]
-    summary.loc[:, "P>|z|"] = float_p
+    key = 'P>|t|' if 'P>|t|' in summary.columns else 'P>|z|'
+    float_p = [float(p) for p in sum_copy[key]]
+    summary.loc[:, key] = float_p
     summary.loc[:, "Significant"] = False
-    summary.loc[summary["P>|z|"] < 0.05, 'Significant'] = True
+    summary.loc[summary[key] < 0.05, 'Significant'] = True
 
     # Standardise returned column name, it seems to vary per test
     if 'Coef.' in summary.columns:

--- a/mne_nirs/statistics/tests/test_statsmodels.py
+++ b/mne_nirs/statistics/tests/test_statsmodels.py
@@ -2,6 +2,8 @@
 #
 # License: BSD (3-clause)
 
+import numpy as np
+import pytest
 import pandas as pd
 import statsmodels.formula.api as smf
 
@@ -11,7 +13,12 @@ from ...statistics import run_GLM, statsmodels_to_results
 from ...utils._io import glm_to_tidy
 
 
-def test_statsmodel_to_df():
+@pytest.mark.parametrize('func', ('mixedlm', 'ols'))
+@pytest.mark.filterwarnings('ignore:.*optimization.*:')
+@pytest.mark.filterwarnings('ignore:.*on the boundary.*:')
+def test_statsmodel_to_df(func):
+    func = getattr(smf, func)
+    np.random.seed(0)
 
     amplitude = 1.432
 
@@ -23,12 +30,13 @@ def test_statsmodel_to_df():
                                 isi_min=15., isi_max=45.)
         design_matrix = make_first_level_design_matrix(raw, stim_dur=5.0)
         glm_est = run_GLM(raw, design_matrix)
-        cha = glm_to_tidy(raw, glm_est, design_matrix)
+        with pytest.warns(RuntimeWarning, match='Non standard source detect'):
+            cha = glm_to_tidy(raw, glm_est, design_matrix)
         cha["ID"] = '%02d' % n
         df_cha = df_cha.append(cha)
     df_cha["theta"] = df_cha["theta"] * 1.0e6
-    roi_model = smf.mixedlm("theta ~ -1 + Condition", df_cha,
-                            groups=df_cha["ID"]).fit(method='nm')
+    roi_model = func("theta ~ -1 + Condition", df_cha,
+                     groups=df_cha["ID"]).fit()
     df = statsmodels_to_results(roi_model)
     assert type(df) == pd.DataFrame
     assert df["Coef."]["Condition[A]"] == amplitude

--- a/mne_nirs/statistics/tests/test_statsmodels.py
+++ b/mne_nirs/statistics/tests/test_statsmodels.py
@@ -13,7 +13,7 @@ from ...statistics import run_GLM, statsmodels_to_results
 from ...utils._io import glm_to_tidy
 
 
-@pytest.mark.parametrize('func', ('mixedlm', 'ols'))
+@pytest.mark.parametrize('func', ('mixedlm', 'ols', 'rlm'))
 @pytest.mark.filterwarnings('ignore:.*optimization.*:')
 @pytest.mark.filterwarnings('ignore:.*on the boundary.*:')
 def test_statsmodel_to_df(func):


### PR DESCRIPTION
I swapped in `smf.ols` for `smf.mixedlm` and needed to change the `P` key to make it work. Adding a test made me add some other stuff so that `pytest mne_nirs/statistics` ran without emitting any warnings.