### PR TITLE
WIP: Add ability to use AR(N) noise models

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,6 @@ dependencies:
 - PySurfer
 - dipy
 - nibabel
-- nilearn>=0.7.0
 - python-picard
 - pyqt!=5.15.3
 - mne>=0.21.0
@@ -40,3 +39,4 @@ dependencies:
 - lxml
 - pip:
   - ipyvtklink
+  - https://github.com/nilearn/nilearn/archive/master.zip

--- a/examples/general/plot_10_hrf_simulation.py
+++ b/examples/general/plot_10_hrf_simulation.py
@@ -181,6 +181,35 @@ print("Estimate:", glm_est['Simulated'].theta[0],
 
 
 ###############################################################################
+# Using models that account for structure in the noise ?
+# ------------------------------------------------------
+#
+# To account for temporal structure in the noise an auto regressive noise
+# model can be used. To account for the noise in the example above we can
+# include a fifth order auto regressive model with the GLM. Given this
+# is a simulation we can verify if the correct estimate of the noise properties
+# was extracted from the data and if this improved the response estimate.
+
+glm_est = run_GLM(raw, design_matrix, noise_model='ar5')
+
+fig, axes = plt.subplots(nrows=1, ncols=1, figsize=(15, 6))
+plt.plot([-0.58853134, -0.29575669, -0.52246482, 0.38735476, 0.02428681],
+         axes=axes)  # actual values from model above
+plt.plot(glm_est['Simulated'].model.rho * -1.0,  axes=axes)  # estimates
+plt.legend(["Simulation AR coefficients", "Estimated AR coefficients"])
+plt.xlabel("Coefficient")
+
+
+###############################################################################
+# We can see that the estimates from the GLM AR model are quite accurate,
+# but how does this affect the accuracy of the response estimate?
+
+print("Estimate:", glm_est['Simulated'].theta[0],
+      "  MSE:", glm_est['Simulated'].MSE,
+      "  Error (uM):", 1e6*(glm_est['Simulated'].theta[0] - amp*1e-6))
+
+
+###############################################################################
 # Conclusion?
 # -----------
 #

--- a/examples/general/plot_10_hrf_simulation.py
+++ b/examples/general/plot_10_hrf_simulation.py
@@ -208,6 +208,9 @@ print("Estimate:", glm_est['Simulated'].theta[0],
       "  MSE:", glm_est['Simulated'].MSE,
       "  Error (uM):", 1e6*(glm_est['Simulated'].theta[0] - amp*1e-6))
 
+###############################################################################
+# The response estimate using the AR(5) model is more accurate than the
+# AR(1) model (error of 0.25 vs 2.8 uM).
 
 ###############################################################################
 # Conclusion?
@@ -219,3 +222,5 @@ print("Estimate:", glm_est['Simulated'].theta[0],
 # estimate provided by the GLM was correct, but contained some error. We
 # observed that as the measurement time was increased, the estimated
 # error decreased.
+# We also observed in this idealised example that including an appropriate
+# model of the noise can improve the accuracy of the response estimate.

--- a/examples/general/plot_10_hrf_simulation.py
+++ b/examples/general/plot_10_hrf_simulation.py
@@ -184,11 +184,12 @@ print("Estimate:", glm_est['Simulated'].theta[0],
 # Using models that account for structure in the noise ?
 # ------------------------------------------------------
 #
-# To account for temporal structure in the noise an auto regressive noise
-# model can be used. To account for the noise in the example above we can
-# include a fifth order auto regressive model with the GLM. Given this
-# is a simulation we can verify if the correct estimate of the noise properties
-# was extracted from the data and if this improved the response estimate.
+# An auto regressive noise model can be used account for temporal structure
+# in the noise. To account for the noise properties in the example above,
+# a fifth order auto regressive model is used below. Given this
+# is a simulation, we can verify if the correct estimate of the noise
+# properties was extracted from the data and if this
+# improved the response estimate.
 
 glm_est = run_GLM(raw, design_matrix, noise_model='ar5')
 

--- a/examples/general/plot_10_hrf_simulation.py
+++ b/examples/general/plot_10_hrf_simulation.py
@@ -181,8 +181,8 @@ print("Estimate:", glm_est['Simulated'].theta[0],
 
 
 ###############################################################################
-# Using models that account for structure in the noise ?
-# ------------------------------------------------------
+# Using autoregressive models in the GLM to account for noise structure
+# ---------------------------------------------------------------------
 #
 # An auto regressive noise model can be used account for temporal structure
 # in the noise. To account for the noise properties in the example above,

--- a/mne_nirs/statistics/_run_GLM.py
+++ b/mne_nirs/statistics/_run_GLM.py
@@ -50,7 +50,6 @@ def run_GLM(raw, design_matrix, noise_model='ar1', bins=0,
 
     if noise_model == 'auto':
         noise_model = f"ar{int(np.round(raw.info['sfreq'] * 4))}"
-    print(noise_model)
 
     if bins == 0:
         bins = len(raw.ch_names)

--- a/mne_nirs/statistics/_run_GLM.py
+++ b/mne_nirs/statistics/_run_GLM.py
@@ -6,7 +6,7 @@ import numpy as np
 from mne.io.pick import _picks_to_idx
 
 
-def run_GLM(raw, design_matrix, noise_model='ar4', bins=0,
+def run_GLM(raw, design_matrix, noise_model='ar1', bins=0,
             n_jobs=1, verbose=0):
     """
     Run GLM on data using supplied design matrix.
@@ -19,10 +19,13 @@ def run_GLM(raw, design_matrix, noise_model='ar4', bins=0,
         The haemoglobin data.
     design_matrix : as specified in Nilearn
         The design matrix.
-    noise_model : {'ar1', 'ols', 'arN'}, optional
-        The temporal variance model. Defaults to 'ar4'.
+    noise_model : {'ar1', 'ols', 'arN', 'auto'}, optional
+        The temporal variance model. Defaults to first order
+        auto regressive model 'ar1'.
         The AR model can be set to any integer value by modifying the value
-        of N.
+        of N. E.g. use `ar5` for a fifth order model.
+        If the string `auto` is provided a model with order 4 times the sample
+        rate will be used.
     bins : int, optional
         Maximum number of discrete bins for the AR coef histogram/clustering.
         By default the value is 0, which will set the number of bins to the
@@ -44,6 +47,10 @@ def run_GLM(raw, design_matrix, noise_model='ar4', bins=0,
 
     picks = _picks_to_idx(raw.info, 'fnirs', exclude=[], allow_empty=True)
     ch_names = raw.ch_names
+
+    if noise_model == 'auto':
+        noise_model = f"ar{int(np.round(raw.info['sfreq'] * 4))}"
+    print(noise_model)
 
     if bins == 0:
         bins = len(raw.ch_names)

--- a/mne_nirs/statistics/_run_GLM.py
+++ b/mne_nirs/statistics/_run_GLM.py
@@ -6,7 +6,7 @@ import numpy as np
 from mne.io.pick import _picks_to_idx
 
 
-def run_GLM(raw, design_matrix, noise_model='ar1', bins=100,
+def run_GLM(raw, design_matrix, noise_model='ar4', bins=0,
             n_jobs=1, verbose=0):
     """
     Run GLM on data using supplied design matrix.
@@ -19,10 +19,15 @@ def run_GLM(raw, design_matrix, noise_model='ar1', bins=100,
         The haemoglobin data.
     design_matrix : as specified in Nilearn
         The design matrix.
-    noise_model : {'ar1', 'ols'}, optional
-        The temporal variance model. Defaults to 'ar1'.
-    bins : : int, optional
-        Maximum number of discrete bins for the AR(1) coef histogram.
+    noise_model : {'ar1', 'ols', 'arN'}, optional
+        The temporal variance model. Defaults to 'ar4'.
+        The AR model can be set to any integer value by modifying the value
+        of N.
+    bins : int, optional
+        Maximum number of discrete bins for the AR coef histogram/clustering.
+        By default the value is 0, which will set the number of bins to the
+        number of channels, effectively estimating the AR model for each
+        channel.
     n_jobs : int, optional
         The number of CPUs to use to do the computation. -1 means
         'all CPUs'.
@@ -39,6 +44,9 @@ def run_GLM(raw, design_matrix, noise_model='ar1', bins=100,
 
     picks = _picks_to_idx(raw.info, 'fnirs', exclude=[], allow_empty=True)
     ch_names = raw.ch_names
+
+    if bins == 0:
+        bins = len(raw.ch_names)
 
     results = dict()
     for pick in picks:

--- a/mne_nirs/statistics/tests/test_statistics.py
+++ b/mne_nirs/statistics/tests/test_statistics.py
@@ -3,12 +3,17 @@
 # License: BSD (3-clause)
 
 import pytest
+import numpy as np
 import nilearn
+
+from mne import Covariance
+from mne.simulation import add_noise
 
 from mne_nirs.experimental_design import make_first_level_design_matrix
 from mne_nirs.statistics import run_GLM
 from mne_nirs.simulation import simulate_nirs_raw
 
+iir_filter = [1., -0.58853134, -0.29575669, -0.52246482, 0.38735476, 0.024286]
 
 @pytest.mark.filterwarnings('ignore:.*nilearn.glm module is experimental.*:')
 def test_run_GLM():
@@ -27,3 +32,39 @@ def test_run_GLM():
     _, ni_est = nilearn.glm.first_level.run_glm(
         raw.get_data(0).T, design_matrix.values)
     assert type(ni_est) == type(glm_estimates)
+
+
+def test_run_GLM_order():
+    raw = simulate_nirs_raw(sig_dur=200, stim_dur=5., sfreq=3)
+    design_matrix = make_first_level_design_matrix(raw, stim_dur=5.,
+                                                   drift_order=1,
+                                                   drift_model='polynomial')
+
+    # Default should be first order AR
+    glm_estimates = run_GLM(raw, design_matrix)
+    assert glm_estimates['Simulated'].model.order == 1
+
+    # Default should be first order AR
+    glm_estimates = run_GLM(raw, design_matrix, noise_model='ar2')
+    assert glm_estimates['Simulated'].model.order == 2
+
+    glm_estimates = run_GLM(raw, design_matrix, noise_model='ar7')
+    assert glm_estimates['Simulated'].model.order == 7
+
+    # Auto should be 4 times sample rate
+    cov = Covariance(np.ones(1) * 1e-11, raw.ch_names,
+                         raw.info['bads'], raw.info['projs'], nfree=0)
+    raw = add_noise(raw, cov, iir_filter=iir_filter)
+    glm_estimates = run_GLM(raw, design_matrix, noise_model='auto')
+    assert glm_estimates['Simulated'].model.order == 3*4
+
+    raw = simulate_nirs_raw(sig_dur=10, stim_dur=5., sfreq=2)
+    cov = Covariance(np.ones(1) * 1e-11, raw.ch_names,
+                         raw.info['bads'], raw.info['projs'], nfree=0)
+    raw = add_noise(raw, cov, iir_filter=iir_filter)
+    design_matrix = make_first_level_design_matrix(raw, stim_dur=5.,
+                                                   drift_order=1,
+                                                   drift_model='polynomial')
+    # Auto should be 4 times sample rate
+    glm_estimates = run_GLM(raw, design_matrix, noise_model='auto')
+    assert glm_estimates['Simulated'].model.order == 2*4

--- a/mne_nirs/statistics/tests/test_statistics.py
+++ b/mne_nirs/statistics/tests/test_statistics.py
@@ -15,6 +15,7 @@ from mne_nirs.simulation import simulate_nirs_raw
 
 iir_filter = [1., -0.58853134, -0.29575669, -0.52246482, 0.38735476, 0.024286]
 
+
 @pytest.mark.filterwarnings('ignore:.*nilearn.glm module is experimental.*:')
 def test_run_GLM():
     raw = simulate_nirs_raw(sig_dur=200, stim_dur=5.)
@@ -53,18 +54,18 @@ def test_run_GLM_order():
 
     # Auto should be 4 times sample rate
     cov = Covariance(np.ones(1) * 1e-11, raw.ch_names,
-                         raw.info['bads'], raw.info['projs'], nfree=0)
+                     raw.info['bads'], raw.info['projs'], nfree=0)
     raw = add_noise(raw, cov, iir_filter=iir_filter)
     glm_estimates = run_GLM(raw, design_matrix, noise_model='auto')
-    assert glm_estimates['Simulated'].model.order == 3*4
+    assert glm_estimates['Simulated'].model.order == 3 * 4
 
     raw = simulate_nirs_raw(sig_dur=10, stim_dur=5., sfreq=2)
     cov = Covariance(np.ones(1) * 1e-11, raw.ch_names,
-                         raw.info['bads'], raw.info['projs'], nfree=0)
+                     raw.info['bads'], raw.info['projs'], nfree=0)
     raw = add_noise(raw, cov, iir_filter=iir_filter)
     design_matrix = make_first_level_design_matrix(raw, stim_dur=5.,
                                                    drift_order=1,
                                                    drift_model='polynomial')
     # Auto should be 4 times sample rate
     glm_estimates = run_GLM(raw, design_matrix, noise_model='auto')
-    assert glm_estimates['Simulated'].model.order == 2*4
+    assert glm_estimates['Simulated'].model.order == 2 * 4

--- a/mne_nirs/statistics/tests/test_statsmodels.py
+++ b/mne_nirs/statistics/tests/test_statsmodels.py
@@ -43,7 +43,7 @@ def test_statsmodel_to_df(func):
                      groups=df_cha["ID"]).fit()
     df = statsmodels_to_results(roi_model)
     assert type(df) == pd.DataFrame
-    assert_allclose(df["Coef."]["Condition[A]"], amplitude, rtol=1e-12)
+    assert_allclose(df["Coef."]["Condition[A]"], amplitude, rtol=0.1)
     assert df["Significant"]["Condition[A]"]
     assert df.shape == (8, 8)
 
@@ -51,6 +51,6 @@ def test_statsmodel_to_df(func):
                         groups=df_cha["ID"]).fit()
     df = statsmodels_to_results(roi_model)
     assert type(df) == pd.DataFrame
-    assert_allclose(df["Coef."]["Condition[A]"], amplitude, rtol=1e-12)
+    assert_allclose(df["Coef."]["Condition[A]"], amplitude, rtol=0.1)
     assert df["Significant"]["Condition[A]"]
     assert df.shape == (8, 8)

--- a/mne_nirs/statistics/tests/test_statsmodels.py
+++ b/mne_nirs/statistics/tests/test_statsmodels.py
@@ -31,6 +31,7 @@ def test_statsmodel_to_df(func):
         raw = simulate_nirs_raw(sfreq=3., amplitude=amplitude,
                                 sig_dur=300., stim_dur=5.,
                                 isi_min=15., isi_max=45.)
+        raw._data += np.random.normal(0, np.sqrt(1e-12), raw._data.shape)
         design_matrix = make_first_level_design_matrix(raw, stim_dur=5.0)
         glm_est = run_GLM(raw, design_matrix)
         with pytest.warns(RuntimeWarning, match='Non standard source detect'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ vtk<8.2; platform_system == "Darwin"
 vtk; platform_system != "Darwin"
 mayavi
 PySurfer[save_movie]
-nilearn
+https://github.com/nilearn/nilearn/archive/master.zip
 xlrd
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1


### PR DESCRIPTION
Now that the nilearn modifications have been merged to master. Change the default behaviour in MNE-NIRS.

Closes #233 

- [x] Leave default noise_model as is.
- [x] Double check the recommendation from Huppert paper. I think it was Fs * 4.
- [x] Set new noise_model option of `auto`, which then auto calculates as above.
- [x] Add tests
- [x] Add example