### PR TITLE
Try and fix pyvista figures with GitHub Actions

### DIFF
--- a/.github/workflows/SphinxBuild_PR.yml
+++ b/.github/workflows/SphinxBuild_PR.yml
@@ -73,3 +73,10 @@ jobs:
         with:
           name: DocumentationHTML
           path: doc/_build/html/
+      - name: Test PyVista
+        run: python -c "import pyvista;pyvista.Sphere().plot(screenshot='sphere3.png')"
+      - name: Upload PyVista test
+        uses: actions/upload-artifact@v2
+        with:
+          name: screenshot3
+          path: sphere3.png

--- a/.github/workflows/SphinxBuild_PR.yml
+++ b/.github/workflows/SphinxBuild_PR.yml
@@ -22,71 +22,67 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          
       - run: ./tools/setup_xvfb.sh
         name: 'Setup xvfb'
+        
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
         name: 'Setup python'
+        
       - shell: bash -el {0}
         run: |
           ./tools/github_actions_dependencies.sh
           source tools/get_minimal_commands.sh
         name: 'Install dependencies'
+        
       - shell: bash -el {0}
         run: |
           pip install --progress-bar off --upgrade -r requirements_doc.txt
         name: 'Install doc dependencies'
+        
       - shell: bash -el {0}
         run: ./tools/github_actions_install.sh
         name: 'Install MNE'
+        
       - shell: bash -el {0}
         run: ./tools/github_actions_infos.sh
         name: 'Show infos'
+        
+      - run: |
+          LD_DEBUG=libs python -c "from PyQt5.QtWidgets import QApplication, QWidget; app = QApplication([])"
+        name: 'Check PyQt5'
 
+      - run: |
+          which python
+          QT_DEBUG_PLUGINS=1 mne sys_info
+          python -c "import numpy; numpy.show_config()"
+          LIBGL_DEBUG=verbose python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
+        name: 'Check installation'
 
-      - shell: bash -el {0}
-        name: Check installation
-        run: |
-           which python
-           QT_DEBUG_PLUGINS=1 mne sys_info
-           python -c "import numpy; numpy.show_config()"
-           LIBGL_DEBUG=verbose python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
-           python -c "import mne; mne.set_config('MNE_USE_CUDA', 'false')"  # this is needed for the config tutorial
-           python -c "import mne; mne.set_config('MNE_LOGGING_LEVEL', 'info')"
-           python -c "import mne; level = mne.get_config('MNE_LOGGING_LEVEL'); assert level.lower() == 'info', repr(level)"
-
-      - name: Test PyVista
-        run: python -c "import pyvista;pyvista.Sphere().plot(screenshot='sphere.png')"
-      - name: Upload PyVista test
-        uses: actions/upload-artifact@v2
-        with:
-          name: screenshot1
-          path: sphere.png
       - shell: bash -el {0}
         run: |
           git reset --hard "$GITHUB_SHA"
           git checkout -q -B "$GITHUB_REF"
           git reset --hard "$GITHUB_SHA"
+          
       - shell: bash -el {0}
         run: |
           git status
-      - name: Test PyVista
-        run: python -c "import pyvista;pyvista.Sphere().plot(screenshot='sphere2.png')"
-      - name: Upload PyVista test
-        uses: actions/upload-artifact@v2
-        with:
-          name: screenshot2
-          path: sphere2.png
+          
       - shell: bash -el {0}
         run: ./tools/github_actions_docs.sh
         name: 'Build docs'
+        
       - uses: actions/upload-artifact@v1
         with:
           name: DocumentationHTML
           path: doc/_build/html/
+          
       - name: Test PyVista
         run: python -c "import pyvista;pyvista.Sphere().plot(screenshot='sphere3.png')"
+        
       - name: Upload PyVista test
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/SphinxBuild_PR.yml
+++ b/.github/workflows/SphinxBuild_PR.yml
@@ -19,6 +19,7 @@ jobs:
       PYTHONUNBUFFERED: '1'
       PYTHON_VERSION: '3.8'
       PYVISTA_OFF_SCREEN: True
+      PYVISTA_USE_IPYVTK: True
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/SphinxBuild_PR.yml
+++ b/.github/workflows/SphinxBuild_PR.yml
@@ -18,8 +18,6 @@ jobs:
       OPENBLAS_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
       PYTHON_VERSION: '3.8'
-      PYVISTA_OFF_SCREEN: True
-      PYVISTA_USE_IPYVTK: True
     steps:
       - uses: actions/checkout@v2
         with:
@@ -45,6 +43,19 @@ jobs:
       - shell: bash -el {0}
         run: ./tools/github_actions_infos.sh
         name: 'Show infos'
+
+
+      - shell: bash -el {0}
+        name: Check installation
+        run: |
+           which python
+           QT_DEBUG_PLUGINS=1 mne sys_info
+           python -c "import numpy; numpy.show_config()"
+           LIBGL_DEBUG=verbose python -c "import pyvistaqt; pyvistaqt.BackgroundPlotter(show=True)"
+           python -c "import mne; mne.set_config('MNE_USE_CUDA', 'false')"  # this is needed for the config tutorial
+           python -c "import mne; mne.set_config('MNE_LOGGING_LEVEL', 'info')"
+           python -c "import mne; level = mne.get_config('MNE_LOGGING_LEVEL'); assert level.lower() == 'info', repr(level)"
+
       - name: Test PyVista
         run: python -c "import pyvista;pyvista.Sphere().plot(screenshot='sphere.png')"
       - name: Upload PyVista test

--- a/.github/workflows/SphinxBuild_PR.yml
+++ b/.github/workflows/SphinxBuild_PR.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   # PIP + non-default stim channel + log level info
   job:
-    name: 'build'
+    name: 'Docs'
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -18,6 +18,7 @@ jobs:
       OPENBLAS_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
       PYTHON_VERSION: '3.8'
+#      PYVISTA_OFF_SCREEN: True
     steps:
       - uses: actions/checkout@v2
         with:
@@ -43,6 +44,13 @@ jobs:
       - shell: bash -el {0}
         run: ./tools/github_actions_infos.sh
         name: 'Show infos'
+      - name: Test PyVista
+        run: python -c "import pyvista;pyvista.Sphere().plot(screenshot='sphere.png')"
+      - name: Upload PyVista test
+        uses: actions/upload-artifact@v2
+        with:
+          name: screenshot1
+          path: sphere.png
       - shell: bash -el {0}
         run: |
           git reset --hard "$GITHUB_SHA"
@@ -51,6 +59,13 @@ jobs:
       - shell: bash -el {0}
         run: |
           git status
+      - name: Test PyVista
+        run: python -c "import pyvista;pyvista.Sphere().plot(screenshot='sphere2.png')"
+      - name: Upload PyVista test
+        uses: actions/upload-artifact@v2
+        with:
+          name: screenshot2
+          path: sphere2.png
       - shell: bash -el {0}
         run: ./tools/github_actions_docs.sh
         name: 'Build docs'

--- a/.github/workflows/SphinxBuild_PR.yml
+++ b/.github/workflows/SphinxBuild_PR.yml
@@ -79,12 +79,3 @@ jobs:
         with:
           name: DocumentationHTML
           path: doc/_build/html/
-          
-      - name: Test PyVista
-        run: python -c "import pyvista;pyvista.Sphere().plot(screenshot='sphere3.png')"
-        
-      - name: Upload PyVista test
-        uses: actions/upload-artifact@v2
-        with:
-          name: screenshot3
-          path: sphere3.png

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,7 @@ from distutils.version import LooseVersion
 import sphinx
 import os
 from sphinx_gallery.sorting import FileNameSortKey
+import pyvista
 
 sys.path.append("../")
 from mne_nirs import __version__  # noqa: E402
@@ -223,6 +224,7 @@ intersphinx_mapping = {
 sphinx_gallery_conf = {
     'doc_module': 'mne_nirs',
     'backreferences_dir': os.path.join('generated'),
+    'image_scrapers': ('pyvista', 'matplotlib'),
     'reference_url': {
         'mne_nirs': None},
     'download_all_examples': False,

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -ef
 
 sudo apt-get update
-sudo apt-get install -yqq libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0
+sudo apt-get install -yqq libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libgl1-mesa-glx
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset


### PR DESCRIPTION
I have split this issue off from #287. That PR highlighted that pyvista plotting works correctly on circleci, but all sphinx-gallery figures turn out as black squares when using GitHub Actions.  See previous discussion https://github.com/mne-tools/mne-nirs/pull/287#issuecomment-860561772 and https://github.com/mne-tools/mne-nirs/pull/287#issuecomment-860725288

I have confirmed this is not a issue with pyvista running on GitHub Actions. See point 3 below.

1. In the CircleCI you can see the correct figure is presented at the bottom of this page. https://1282-254026779-gh.circle-artifacts.com/0/dev/pull/297/auto_examples/general/plot_01_data_io.html#custom-data-import
2. However, in the GitHub Actions build it is just a black square. You can see this by downloading the documentation artefact from the build at https://github.com/mne-tools/mne-nirs/pull/297/checks?check_run_id=2827440875 and going to `refs-11/pull/297/merge/auto_examples/general/plot_01_data_io.html`
3. To check that GitHub Actions has pyvista installed correctly I have added a minimal pyvista command to the GitHub action, and it correctly generates a 3d figure. See the screenshot artefacts in the above action. And https://github.com/pyvista/test-pyvista-gh-action/pull/3