### PR TITLE
MAINT: Update for Hitachi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
         - run:
             name: Install 3D rendering libraries \ PyQt5 dependencies \ graphviz \ optipng (for optimized images)
             command: |
+              sudo apt-get update
               sudo apt-get install libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 \
                   libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 \
                   graphviz \
@@ -40,7 +41,7 @@ jobs:
 
         - run:
             <<: *xvfb
-            
+
         - run:
             name: Install fonts needed for diagrams
             command: |
@@ -48,8 +49,8 @@ jobs:
               curl https://codeload.github.com/adobe-fonts/source-code-pro/tar.gz/2.038R-ro/1.058R-it/1.018R-VAR | tar xz -C $HOME/.fonts
               curl https://codeload.github.com/adobe-fonts/source-sans-pro/tar.gz/3.028R | tar xz -C $HOME/.fonts
               fc-cache -f
-            
-            
+
+
         - run:
             name: Install fonts needed for diagrams
             command: |
@@ -79,8 +80,8 @@ jobs:
         - run:
             name: Check PyQt5
             command: LD_DEBUG=libs python -c "from PyQt5.QtWidgets import QApplication, QWidget; app = QApplication([])"
-            
-            
+
+
         # Look at what we have and fail early if there is some library conflict
         # (remove irrelevant lines compared to MNE-Python)
         - run:

--- a/mne_nirs/preprocessing/_peak_power.py
+++ b/mne_nirs/preprocessing/_peak_power.py
@@ -9,8 +9,7 @@ from scipy.signal import periodogram
 from mne import pick_types
 from mne.io import BaseRaw
 from mne.utils import _validate_type, verbose
-from mne.preprocessing.nirs import (_channel_frequencies,
-                                    _check_channels_ordered)
+from mne.preprocessing.nirs import _validate_nirs_info
 from mne.filter import filter_data
 
 
@@ -61,8 +60,7 @@ def peak_power(raw, time_window=10, threshold=0.1, l_freq=0.7, h_freq=1.5,
         raise RuntimeError('Scalp coupling index '
                            'should be run on optical density data.')
 
-    freqs = np.unique(_channel_frequencies(raw.info))
-    picks = _check_channels_ordered(raw.info, freqs)
+    picks = _validate_nirs_info(raw.info)
 
     filtered_data = filter_data(raw._data, raw.info['sfreq'], l_freq, h_freq,
                                 picks=picks, verbose=verbose,

--- a/mne_nirs/preprocessing/_peak_power.py
+++ b/mne_nirs/preprocessing/_peak_power.py
@@ -87,8 +87,9 @@ def peak_power(raw, time_window=10, threshold=0.1, l_freq=0.7, h_freq=1.5,
             c1 = filtered_data[ii][start_sample:end_sample]
             c2 = filtered_data[ii + 1][start_sample:end_sample]
 
-            c1 = c1 / np.std(c1)
-            c2 = c2 / np.std(c2)
+            # protect against zero
+            c1 = c1 / (np.std(c1) or 1)
+            c2 = c2 / (np.std(c2) or 1)
 
             c = np.correlate(c1, c2, "full")
             c = c / (window_samples)

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -14,7 +14,7 @@ else # pip 3.9 (missing statsmodels and dipy)
 	# built using vtk master branch on an Ubuntu 18.04.5 VM and uploaded to OSF:
 #	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 #	pip install vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
-        pip install 'vtk<=9.0.1'
+  pip install vtk
 	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/5ee02e2f295f667e33f11e71946e774cca40256c
 	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
 	pip install --progress-bar off --upgrade --pre PyQt5

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -14,7 +14,7 @@ else # pip 3.9 (missing statsmodels and dipy)
 	# built using vtk master branch on an Ubuntu 18.04.5 VM and uploaded to OSF:
 #	wget -q https://osf.io/kej3v/download -O vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
 #	pip install vtk-9.0.20201117-cp39-cp39-linux_x86_64.whl
-  pip install vtk
+        pip install 'vtk<=9.0.1'
 	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/5ee02e2f295f667e33f11e71946e774cca40256c
 	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
 	pip install --progress-bar off --upgrade --pre PyQt5


### PR DESCRIPTION
Use newer method for verifying freqs to avoid:
```
  File "<decorator-gen-528>", line 22, in peak_power
  File "/home/larsoner/python/mne-nirs/mne_nirs/preprocessing/_peak_power.py", line 65, in peak_power
    picks = _check_channels_ordered(raw.info, freqs)
  File "/home/larsoner/python/mne-python/mne/preprocessing/nirs/nirs.py", line 159, in _check_channels_ordered
    raise ValueError(
ValueError: NIRS channels not ordered correctly. Channels must be ordered as source detector pairs with alternating frequencies: 698 & 699
```