### PR TITLE
Fix snirf file inconsistencies with the spec

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ MNE-NIRS: Near-Infrared Spectroscopy Analysis
 
 **MNE-NIRS** is an `MNE-Python <https://mne.tools>`_ compatible near-infrared spectroscopy processing package. 
 
-MNE-Python provides support for fNIRS analysis, this package extends that functionality and adds additional GLM style analysis, helper functions, algorithms, data quality metrics, plotting, and additional file format support.
+MNE-Python provides support for fNIRS analysis, this package extends that functionality and adds GLM analysis, helper functions, additional algorithms, data quality metrics, plotting, and file format support.
 
 
 Documentation

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ MNE-NIRS: Near-Infrared Spectroscopy Analysis
 
 **MNE-NIRS** is an `MNE-Python <https://mne.tools>`_ compatible near-infrared spectroscopy processing package. 
 
-MNE-Python provides support for a subset of fNIRS waveform analysis, this package extends that functionality and adds additional GLM style analysis, helper functions, algorithms, data quality metrics, and plotting.
+MNE-Python provides support for fNIRS analysis, this package extends that functionality and adds additional GLM style analysis, helper functions, algorithms, data quality metrics, plotting, and additional file format support.
 
 
 Documentation

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -37,6 +37,9 @@ Enhancements
 * Add :meth:`mne_nirs.statistics.RegressionResults.scatter` to display GLM results as a scatter plot.
 * Add :meth:`mne_nirs.statistics.RegressionResults.surface_projection` to display GLM results on a cortical surface.
 
+Bugs
+
+* Fix inconsistencies between files written via :meth:`mne_nirs.io.snirf.write_raw_snirf` and the `current version <https://github.com/fNIRS/snirf/blob/52de9a6724ddd0c9dcd36d8d11007895fed74205/snirf_specification.md>`_ of the official SNIRF spec. By `Darin Erat Sleiter`_.
 
 Infrastructure
 
@@ -71,3 +74,4 @@ Enhancements
 
 .. _Robert Luke: https://github.com/rob-luke/
 .. _Eric Larson: https://github.com/larsoner/
+.. _Darin Erat Sleiter: https://github.com/dsleiter

--- a/mne_nirs/datasets/fnirs_motor_group/fnirs_motor_group.py
+++ b/mne_nirs/datasets/fnirs_motor_group/fnirs_motor_group.py
@@ -26,7 +26,7 @@ def data_path(path=None, force_update=False, update_path=True, download=True,
     if not op.isdir(datapath + "/MNE-fNIRS-motor-group-data/"):
         remove_archive, full = _download(datapath, downloadpath,
                                          "MNE-fNIRS-motor-group-data.zip",
-                                         "10d2976fd0844a6c44b6355a9a212611")
+                                         "8b1a09e4af64ec66426b9c70c07a5594")
         _extract(datapath, "fNIRS-motor-group",
                  op.join(datapath, "MNE-fNIRS-motor-group-data"),
                  full, op.join(datapath, "BIDS-NIRS-Tapping-master"), True)

--- a/mne_nirs/io/snirf/__init__.py
+++ b/mne_nirs/io/snirf/__init__.py
@@ -2,4 +2,4 @@
 #
 # License: BSD (3-clause)
 
-from ._snirf import write_raw_snirf
+from ._snirf import write_raw_snirf, SPEC_FORMAT_VERSION

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -21,17 +21,17 @@ def write_raw_snirf(raw, fname):
         Path to the SNIRF data file.
     """
 
-    picks = _picks_to_idx(raw.info, "fnirs_cw_amplitude", exclude=[])
-    assert len(picks) == len(raw.ch_names), "Data must be fnirs_cw_amplitude"
+    picks = _picks_to_idx(raw.info, 'fnirs_cw_amplitude', exclude=[])
+    assert len(picks) == len(raw.ch_names), 'Data must be fnirs_cw_amplitude'
 
     # Reordering channels
     num_chans = len(raw.ch_names)
     raw = raw.copy()
     raw.pick(picks=list(range(num_chans)[0::2]) + list(range(num_chans)[1::2]))
 
-    with h5py.File(fname, "w") as f:
-        nirs = f.create_group("/nirs")
-        f.create_dataset("formatVersion", data=[_str_encode("1.0")])
+    with h5py.File(fname, 'w') as f:
+        nirs = f.create_group('/nirs')
+        f.create_dataset('formatVersion', data=[_str_encode('1.0')])
 
         _add_metadata_tags(raw, nirs)
         _add_single_data_block(raw, nirs)
@@ -47,7 +47,7 @@ def _str_encode(str_val):
     str_val : str
         The string to encode.
     """
-    return str_val.encode("UTF-8")
+    return str_val.encode('UTF-8')
 
 
 def _add_metadata_tags(raw, nirs):
@@ -60,42 +60,42 @@ def _add_metadata_tags(raw, nirs):
     nirs : hpy5.Group
         The root hdf5 nirs group to which the metadata should beadded.
     """
-    metadata_tags = nirs.create_group("metaDataTags")
+    metadata_tags = nirs.create_group('metaDataTags')
 
     # Store measurement and birth date
-    datestr = raw.info["meas_date"].strftime("%Y-%m-%d")
-    timestr = raw.info["meas_date"].strftime("%H:%M:%SZ")
-    birthday = datetime.date(*raw.info["subject_info"]["birthday"])
-    birthstr = birthday.strftime("%Y-%m-%d")
-    metadata_tags.create_dataset("MeasurementDate",
+    datestr = raw.info['meas_date'].strftime('%Y-%m-%d')
+    timestr = raw.info['meas_date'].strftime('%H:%M:%SZ')
+    birthday = datetime.date(*raw.info['subject_info']['birthday'])
+    birthstr = birthday.strftime('%Y-%m-%d')
+    metadata_tags.create_dataset('MeasurementDate',
                                  data=[_str_encode(datestr)])
-    metadata_tags.create_dataset("MeasurementTime",
+    metadata_tags.create_dataset('MeasurementTime',
                                  data=[_str_encode(timestr)])
-    metadata_tags.create_dataset("DateOfBirth", data=[_str_encode(birthstr)])
+    metadata_tags.create_dataset('DateOfBirth', data=[_str_encode(birthstr)])
 
     # Store demographic info
-    subject_id = raw.info["subject_info"]["first_name"]
-    metadata_tags.create_dataset("SubjectID", data=[_str_encode(subject_id)])
+    subject_id = raw.info['subject_info']['first_name']
+    metadata_tags.create_dataset('SubjectID', data=[_str_encode(subject_id)])
 
     # Store the units of measurement
-    metadata_tags.create_dataset("LengthUnit", data=[_str_encode("m")])
-    metadata_tags.create_dataset("TimeUnit", data=[_str_encode("s")])
-    metadata_tags.create_dataset("FrequencyUnit", data=[_str_encode("Hz")])
+    metadata_tags.create_dataset('LengthUnit', data=[_str_encode('m')])
+    metadata_tags.create_dataset('TimeUnit', data=[_str_encode('s')])
+    metadata_tags.create_dataset('FrequencyUnit', data=[_str_encode('Hz')])
 
     # Add non standard (but allowed) custom metadata tags
-    if "middle_name" in raw.info["subject_info"]:
-        middle_name = raw.info["subject_info"]["middle_name"]
-        metadata_tags.create_dataset("middleName",
+    if 'middle_name' in raw.info['subject_info']:
+        middle_name = raw.info['subject_info']['middle_name']
+        metadata_tags.create_dataset('middleName',
                                      data=[_str_encode(middle_name)])
-    if "last_name" in raw.info["subject_info"]:
-        last_name = raw.info["subject_info"]["last_name"]
-        metadata_tags.create_dataset("lastName", data=[_str_encode(last_name)])
-    if "sex" in raw.info["subject_info"]:
-        sex = str(int(raw.info["subject_info"]["sex"]))
-        metadata_tags.create_dataset("sex", data=[_str_encode(sex)])
-    if raw.info["dig"] is not None:
-        coord_frame_id = int(raw.info["dig"][0].get("coord_frame"))
-        metadata_tags.create_dataset("MNE_coordFrame", data=[coord_frame_id])
+    if 'last_name' in raw.info['subject_info']:
+        last_name = raw.info['subject_info']['last_name']
+        metadata_tags.create_dataset('lastName', data=[_str_encode(last_name)])
+    if 'sex' in raw.info['subject_info']:
+        sex = str(int(raw.info['subject_info']['sex']))
+        metadata_tags.create_dataset('sex', data=[_str_encode(sex)])
+    if raw.info['dig'] is not None:
+        coord_frame_id = int(raw.info['dig'][0].get('coord_frame'))
+        metadata_tags.create_dataset('MNE_coordFrame', data=[coord_frame_id])
 
 
 def _add_single_data_block(raw, nirs):
@@ -111,9 +111,9 @@ def _add_single_data_block(raw, nirs):
     nirs : hpy5.Group
         The root hdf5 nirs group to which the data should be added.
     """
-    data_block = nirs.create_group("data1")
-    data_block.create_dataset("dataTimeSeries", data=raw.get_data().T)
-    data_block.create_dataset("time", data=raw.times)
+    data_block = nirs.create_group('data1')
+    data_block.create_dataset('dataTimeSeries', data=raw.get_data().T)
+    data_block.create_dataset('time', data=raw.times)
 
     _add_measurement_lists(raw, data_block)
 
@@ -133,19 +133,19 @@ def _add_measurement_lists(raw, data_block):
     wavelengths = _get_unique_wavelength_list(raw)
 
     for idx, ch_name in enumerate(raw.ch_names, start=1):
-        ml_id = f"measurementList{idx}"
+        ml_id = f'measurementList{idx}'
         ch_group = data_block.require_group(ml_id)
 
         source_idx = sources.index(_extract_source(ch_name)) + 1
         detector_idx = detectors.index(_extract_detector(ch_name)) + 1
         wavelength_idx = wavelengths.index(_extract_wavelength(ch_name)) + 1
-        ch_group.create_dataset("sourceIndex", data=[source_idx])
-        ch_group.create_dataset("detectorIndex", data=[detector_idx])
-        ch_group.create_dataset("wavelengthIndex", data=[wavelength_idx])
+        ch_group.create_dataset('sourceIndex', data=[source_idx])
+        ch_group.create_dataset('detectorIndex', data=[detector_idx])
+        ch_group.create_dataset('wavelengthIndex', data=[wavelength_idx])
 
         # Set dataType and dataTypeIndex for CW Amplitude measurements
-        ch_group.create_dataset("dataType", data=1)
-        ch_group.create_dataset("dataTypeIndex", data=1)
+        ch_group.create_dataset('dataType', data=1)
+        ch_group.create_dataset('dataTypeIndex', data=1)
 
 
 def _add_probe_info(raw, nirs):
@@ -162,14 +162,14 @@ def _add_probe_info(raw, nirs):
     detectors = _get_unique_detector_list(raw)
     wavelengths = _get_unique_wavelength_list(raw)
 
-    probe = nirs.create_group("probe")
+    probe = nirs.create_group('probe')
 
     # Store source/detector/wavelength info
-    encoded_source_labels = [_str_encode(f"S{src}") for src in sources]
-    encoded_detector_labels = [_str_encode(f"D{det}") for det in detectors]
-    probe.create_dataset("sourceLabels", data=encoded_source_labels)
-    probe.create_dataset("detectorLabels", data=encoded_detector_labels)
-    probe.create_dataset("wavelengths", data=wavelengths)
+    encoded_source_labels = [_str_encode(f'S{src}') for src in sources]
+    encoded_detector_labels = [_str_encode(f'D{det}') for det in detectors]
+    probe.create_dataset('sourceLabels', data=encoded_source_labels)
+    probe.create_dataset('detectorLabels', data=encoded_detector_labels)
+    probe.create_dataset('wavelengths', data=wavelengths)
 
     # Create 3d locs and store
     ch_sources = [_extract_source(ch) for ch in raw.ch_names]
@@ -178,15 +178,15 @@ def _add_probe_info(raw, nirs):
     detlocs = np.empty((len(detectors), 3))
     for i, src in enumerate(sources):
         idx = ch_sources.index(src)
-        srclocs[i, :] = raw.info["chs"][idx]["loc"][3:6]
+        srclocs[i, :] = raw.info['chs'][idx]['loc'][3:6]
     for i, det in enumerate(detectors):
         idx = ch_detectors.index(det)
-        detlocs[i, :] = raw.info["chs"][idx]["loc"][6:9]
-    probe.create_dataset("sourcePos3D", data=srclocs)
-    probe.create_dataset("detectorPos3D", data=detlocs)
+        detlocs[i, :] = raw.info['chs'][idx]['loc'][6:9]
+    probe.create_dataset('sourcePos3D', data=srclocs)
+    probe.create_dataset('detectorPos3D', data=detlocs)
 
     # Store probe landmarks
-    if raw.info["dig"] is not None:
+    if raw.info['dig'] is not None:
         _store_probe_landmarks(raw, probe)
 
 
@@ -200,19 +200,19 @@ def _store_probe_landmarks(raw, probe):
     probe : hpy5.Group
         The hdf5 probe group to which the landmark info should be added.
     """
-    diglocs = np.empty((len(raw.info["dig"]), 3))
+    diglocs = np.empty((len(raw.info['dig']), 3))
     digname = list()
-    for idx, dig in enumerate(raw.info["dig"]):
-        ident = re.match(r"\d+ \(FIFFV_POINT_(\w+)\)",
-                         str(dig.get("ident")))
+    for idx, dig in enumerate(raw.info['dig']):
+        ident = re.match(r'\d+ \(FIFFV_POINT_(\w+)\)',
+                         str(dig.get('ident')))
         if ident is not None:
             digname.append(ident[1])
         else:
-            digname.append(str(dig.get("ident")))
-        diglocs[idx, :] = dig.get("r")
+            digname.append(str(dig.get('ident')))
+        diglocs[idx, :] = dig.get('r')
     digname = [_str_encode(d) for d in digname]
-    probe.create_dataset("landmarkPos3D", data=diglocs)
-    probe.create_dataset("landmarkLabels", data=digname)
+    probe.create_dataset('landmarkPos3D', data=diglocs)
+    probe.create_dataset('landmarkLabels', data=digname)
 
 
 def _add_stim_info(raw, nirs):
@@ -228,14 +228,14 @@ def _add_stim_info(raw, nirs):
     # Convert MNE annotations to SNIRF stims
     descriptions = np.unique(raw.annotations.description)
     for idx, desc in enumerate(descriptions, start=1):
-        stim_group = nirs.create_group(f"stim{idx}")
+        stim_group = nirs.create_group(f'stim{idx}')
         trgs = np.where(raw.annotations.description == desc)[0]
         stims = np.zeros((len(trgs), 3))
         for idx, trg in enumerate(trgs):
             stims[idx, :] = [raw.annotations.onset[trg], 5.0,
                              raw.annotations.duration[trg]]
-        stim_group.create_dataset("data", data=stims)
-        stim_group.create_dataset("name", data=[_str_encode(desc)])
+        stim_group.create_dataset('data', data=stims)
+        stim_group.create_dataset('name', data=[_str_encode(desc)])
 
 
 def _get_unique_source_list(raw):
@@ -285,10 +285,10 @@ def _match_channel_pattern(channel_name):
     channel_name : str
         The name of the channel.
     """
-    rgx = r"^S(?P<source>\d+)_D(?P<detector>\d+) (?P<wavelength>\d+)$"
+    rgx = r'^S(?P<source>\d+)_D(?P<detector>\d+) (?P<wavelength>\d+)$'
     match = re.fullmatch(rgx, channel_name)
     if match is None:
-        msg = f"channel name does not match expected pattern: {channel_name}"
+        msg = f'channel name does not match expected pattern: {channel_name}'
         raise ValueError(msg)
     return match
 
@@ -303,7 +303,7 @@ def _extract_source(channel_name):
     channel_name : str
         The name of the channel.
     """
-    return int(_match_channel_pattern(channel_name).group("source"))
+    return int(_match_channel_pattern(channel_name).group('source'))
 
 
 def _extract_detector(channel_name):
@@ -316,7 +316,7 @@ def _extract_detector(channel_name):
     channel_name : str
         The name of the channel.
     """
-    return int(_match_channel_pattern(channel_name).group("detector"))
+    return int(_match_channel_pattern(channel_name).group('detector'))
 
 
 def _extract_wavelength(channel_name):
@@ -329,4 +329,4 @@ def _extract_wavelength(channel_name):
     channel_name : str
         The name of the channel.
     """
-    return float(_match_channel_pattern(channel_name).group("wavelength"))
+    return float(_match_channel_pattern(channel_name).group('wavelength'))

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -10,6 +10,11 @@ import numpy as np
 from mne.io.pick import _picks_to_idx
 
 
+# The currently-implemented spec can be found here:
+# https://github.com/fNIRS/snirf/blob/52de9a6724ddd0c9dcd36d8d11007895fed74205/snirf_specification.md
+SPEC_FORMAT_VERSION = '1.0 - Draft 3'
+
+
 def write_raw_snirf(raw, fname):
     """Write continuous wave data to disk in SNIRF format.
 
@@ -31,7 +36,8 @@ def write_raw_snirf(raw, fname):
 
     with h5py.File(fname, 'w') as f:
         nirs = f.create_group('/nirs')
-        f.create_dataset('formatVersion', data=[_str_encode('1.0')])
+        f.create_dataset('formatVersion',
+                         data=[_str_encode(SPEC_FORMAT_VERSION)])
 
         _add_metadata_tags(raw, nirs)
         _add_single_data_block(raw, nirs)

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -275,7 +275,7 @@ def _get_unique_wavelength_list(raw):
 
 
 def _match_channel_pattern(channel_name):
-    """Returns a regex match agains the expected channel name format.
+    """Returns a regex match against the expected channel name format.
 
     The returned match object contains three named groups: source, detector,
     and wavelength. If no match is found, a ValueError is raised.

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -21,7 +21,7 @@ def write_raw_snirf(raw, fname):
         Path to the SNIRF data file.
     """
 
-    picks = _picks_to_idx(raw.info, 'fnirs_cw_amplitude', exclude=[])
+    picks = _picks_to_idx(raw.info, "fnirs_cw_amplitude", exclude=[])
     assert len(picks) == len(raw.ch_names), "Data must be fnirs_cw_amplitude"
 
     # Reordering channels
@@ -31,11 +31,23 @@ def write_raw_snirf(raw, fname):
 
     with h5py.File(fname, "w") as f:
         nirs = f.create_group("/nirs")
+        f.create_dataset("formatVersion", data=[_str_encode("1.0")])
 
         _add_metadata_tags(raw, nirs)
         _add_single_data_block(raw, nirs)
         _add_probe_info(raw, nirs)
         _add_stim_info(raw, nirs)
+
+
+def _str_encode(str_val):
+    """Encode a string for use in an h5py Dataset.
+
+    Parameters
+    ----------
+    str_val : str
+        The string to encode.
+    """
+    return str_val.encode("UTF-8")
 
 
 def _add_metadata_tags(raw, nirs):
@@ -62,37 +74,28 @@ def _add_metadata_tags(raw, nirs):
     metadata_tags.create_dataset("DateOfBirth", data=[_str_encode(birthstr)])
 
     # Store demographic info
-    subject_id = raw.info["subject_info"]['first_name']
+    subject_id = raw.info["subject_info"]["first_name"]
     metadata_tags.create_dataset("SubjectID", data=[_str_encode(subject_id)])
 
     # Store the units of measurement
-    metadata_tags.create_dataset("LengthUnit", data=[_str_encode('m')])
+    metadata_tags.create_dataset("LengthUnit", data=[_str_encode("m")])
+    metadata_tags.create_dataset("TimeUnit", data=[_str_encode("s")])
+    metadata_tags.create_dataset("FrequencyUnit", data=[_str_encode("Hz")])
 
     # Add non standard (but allowed) custom metadata tags
-    if 'middle_name' in raw.info["subject_info"]:
-        middle_name = raw.info["subject_info"]['middle_name']
+    if "middle_name" in raw.info["subject_info"]:
+        middle_name = raw.info["subject_info"]["middle_name"]
         metadata_tags.create_dataset("middleName",
                                      data=[_str_encode(middle_name)])
-    if 'last_name' in raw.info["subject_info"]:
-        last_name = raw.info["subject_info"]['last_name']
+    if "last_name" in raw.info["subject_info"]:
+        last_name = raw.info["subject_info"]["last_name"]
         metadata_tags.create_dataset("lastName", data=[_str_encode(last_name)])
-    if 'sex' in raw.info["subject_info"]:
-        sex = str(int(raw.info["subject_info"]['sex']))
+    if "sex" in raw.info["subject_info"]:
+        sex = str(int(raw.info["subject_info"]["sex"]))
         metadata_tags.create_dataset("sex", data=[_str_encode(sex)])
-    if raw.info['dig'] is not None:
-        coord_frame_id = int(raw.info['dig'][0].get("coord_frame"))
+    if raw.info["dig"] is not None:
+        coord_frame_id = int(raw.info["dig"][0].get("coord_frame"))
         metadata_tags.create_dataset("MNE_coordFrame", data=[coord_frame_id])
-
-
-def _str_encode(str_val):
-    """Encode a string for use in an h5py Dataset.
-
-    Parameters
-    ----------
-    str_val : str
-        The string to encode.
-    """
-    return str_val.encode('UTF-8')
 
 
 def _add_single_data_block(raw, nirs):
@@ -125,15 +128,12 @@ def _add_measurement_lists(raw, data_block):
     data_block : hpy5.Group
         The hdf5 data1 group to which the measurement lists should be added.
     """
-    # Prep data for storing each MNE channel as SNIRF measurementList
-    data_block.create_dataset("measurementList1/dataType", data=1)
-
     sources = _get_source_list(raw)
     detectors = _get_detector_list(raw)
     wavelengths = _get_wavelength_list(raw)
 
     for idx, ch_name in enumerate(raw.ch_names, start=1):
-        ml_id = f'measurementList{idx}'
+        ml_id = f"measurementList{idx}"
         ch_group = data_block.require_group(ml_id)
 
         source_idx = sources.index(_extract_source(ch_name)) + 1
@@ -142,6 +142,10 @@ def _add_measurement_lists(raw, data_block):
         ch_group.create_dataset("sourceIndex", data=[source_idx])
         ch_group.create_dataset("detectorIndex", data=[detector_idx])
         ch_group.create_dataset("wavelengthIndex", data=[wavelength_idx])
+
+        # Set dataType and dataTypeIndex for CW Amplitude measurements
+        ch_group.create_dataset("dataType", data=1)
+        ch_group.create_dataset("dataTypeIndex", data=1)
 
 
 def _add_probe_info(raw, nirs):
@@ -161,8 +165,8 @@ def _add_probe_info(raw, nirs):
     probe = nirs.create_group("probe")
 
     # Store source/detector/wavelength info
-    encoded_source_labels = [_str_encode(f'S{src}') for src in sources]
-    encoded_detector_labels = [_str_encode(f'D{det}') for det in detectors]
+    encoded_source_labels = [_str_encode(f"S{src}") for src in sources]
+    encoded_detector_labels = [_str_encode(f"D{det}") for det in detectors]
     probe.create_dataset("sourceLabels", data=encoded_source_labels)
     probe.create_dataset("detectorLabels", data=encoded_detector_labels)
     probe.create_dataset("wavelengths", data=wavelengths)
@@ -174,15 +178,15 @@ def _add_probe_info(raw, nirs):
     detlocs = np.empty((len(detectors), 3))
     for i, src in enumerate(sources):
         idx = ch_sources.index(float(src))
-        srclocs[i, :] = raw.info['chs'][idx]['loc'][3:6]
+        srclocs[i, :] = raw.info["chs"][idx]["loc"][3:6]
     for i, det in enumerate(detectors):
         idx = ch_detectors.index(float(det))
-        detlocs[i, :] = raw.info['chs'][idx]['loc'][6:9]
+        detlocs[i, :] = raw.info["chs"][idx]["loc"][6:9]
     probe.create_dataset("sourcePos3D", data=srclocs)
     probe.create_dataset("detectorPos3D", data=detlocs)
 
     # Store probe landmarks
-    if raw.info['dig'] is not None:
+    if raw.info["dig"] is not None:
         _store_probe_landmarks(raw, probe)
 
 
@@ -196,9 +200,9 @@ def _store_probe_landmarks(raw, probe):
     probe : hpy5.Group
         The hdf5 probe group to which the landmark info should be added.
     """
-    diglocs = np.empty((len(raw.info['dig']), 3))
+    diglocs = np.empty((len(raw.info["dig"]), 3))
     digname = list()
-    for idx, dig in enumerate(raw.info['dig']):
+    for idx, dig in enumerate(raw.info["dig"]):
         ident = re.match(r"\d+ \(FIFFV_POINT_(\w+)\)",
                          str(dig.get("ident")))
         if ident is not None:
@@ -222,15 +226,16 @@ def _add_stim_info(raw, nirs):
         The root hdf5 nirs group to which the stimuli info should be added.
     """
     # Convert MNE annotations to SNIRF stims
-    for desc in np.unique(raw.annotations.description):
-        key = "stim" + desc
+    for idx, desc in enumerate(np.unique(raw.annotations.description), start=1):
+        stim_group = nirs.create_group(f"stim{idx}")
         trgs = np.where(raw.annotations.description == desc)[0]
         stims = np.zeros((len(trgs), 3))
         for idx, trg in enumerate(trgs):
             stims[idx, :] = [raw.annotations.onset[trg], 5.0,
                              raw.annotations.duration[trg]]
-        stim_group = nirs.create_group(key)
-        stim_group.create_dataset('data', data=stims)
+        
+        stim_group.create_dataset("data", data=stims)
+        stim_group.create_dataset("name", data=[_str_encode(desc)])
 
 
 def _get_source_list(raw):
@@ -249,17 +254,17 @@ def _get_wavelength_list(raw):
 
 
 def _match_channel_pattern(channel_name):
-    rgx = r'^S(?P<source>\d+)_D(?P<detector>\d+) (?P<wavelength>\d+)$'
+    rgx = r"^S(?P<source>\d+)_D(?P<detector>\d+) (?P<wavelength>\d+)$"
     return re.fullmatch(rgx, channel_name)
 
 
 def _extract_source(channel_name):
-    return int(_match_channel_pattern(channel_name).group('source'))
+    return int(_match_channel_pattern(channel_name).group("source"))
 
 
 def _extract_detector(channel_name):
-    return int(_match_channel_pattern(channel_name).group('detector'))
+    return int(_match_channel_pattern(channel_name).group("detector"))
 
 
 def _extract_wavelength(channel_name):
-    return float(_match_channel_pattern(channel_name).group('wavelength'))
+    return float(_match_channel_pattern(channel_name).group("wavelength"))

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -2,6 +2,8 @@
 #
 # License: BSD (3-clause)
 
+import datetime
+
 import h5py as h5py
 import re
 import numpy as np
@@ -28,130 +30,236 @@ def write_raw_snirf(raw, fname):
     raw.pick(picks=list(range(num_chans)[0::2]) + list(range(num_chans)[1::2]))
 
     with h5py.File(fname, "w") as f:
-        f.create_dataset("nirs/data1/measurementList1/dataType", data=1)
-        f.create_dataset("/nirs/data1/dataTimeSeries", data=raw.get_data().T)
-        f.create_dataset("/nirs/data1/time", data=raw.times)
+        nirs = f.create_group("/nirs")
 
-        # Store measurement and birth date
-        datestr = raw.info["meas_date"].strftime("%Y-%m-%d")
-        timestr = raw.info["meas_date"].strftime("%H:%M:%SZ")
-        birthstr = '{0:02d}-{1:02d}-{2:02d}'.format(
-            raw.info["subject_info"]['birthday'][0],
-            raw.info["subject_info"]['birthday'][1],
-            raw.info["subject_info"]['birthday'][2])
-        f.create_dataset("nirs/metaDataTags/"
-                         "MeasurementDate", data=[datestr.encode('UTF-8')])
-        f.create_dataset("nirs/metaDataTags/"
-                         "MeasurementTime", data=[timestr.encode('UTF-8')])
-        f.create_dataset("nirs/metaDataTags/"
-                         "DateOfBirth", data=[birthstr.encode('UTF-8')])
+        _add_metadata_tags(raw, nirs)
+        _add_single_data_block(raw, nirs)
+        _add_probe_info(raw, nirs)
+        _add_stim_info(raw, nirs)
 
-        # Extract info from file names
-        rgx = r'S(\d+)_D(\d+) (\d+)'
-        chs = raw.info['chs']
-        sources = [float(re.match(rgx, r['ch_name']).groups()[0])
-                   for r in chs]
-        detectors = [float(re.match(rgx, r['ch_name']).groups()[1])
-                     for r in chs]
-        wavelengths = [float(re.match(rgx, r['ch_name']).groups()[2])
-                       for r in chs]
 
-        # Create info summary and recode
-        sources_sorted = np.sort(np.unique(sources))
-        detectors_sorted = np.sort(np.unique(detectors))
-        wavelengths_sorted = np.sort(np.unique(wavelengths))
-        sources_sorted = [str(int(src)).encode('UTF-8')
-                          for src in sources_sorted]
-        detectors_sorted = [str(int(det)).encode('UTF-8')
-                            for det in detectors_sorted]
-        wavelengths_sorted = [str(wve).encode('UTF-8')
-                              for wve in wavelengths_sorted]
+def _add_metadata_tags(raw, nirs):
+    """Creates and adds elements to the nirs metaDataTags group.
 
-        # Store source/detector/wavelength info
-        f.create_dataset("nirs/probe/sourceLabels",
-                         data=[('S'.encode('UTF-8') + src)
-                               for src in sources_sorted])
-        f.create_dataset("nirs/probe/detectorLabels",
-                         data=[('D'.encode('UTF-8') + det)
-                               for det in detectors_sorted])
-        f.create_dataset("nirs/probe/wavelengths",
-                         data=[float(wve)
-                               for wve in wavelengths_sorted])
+    Parameters
+    ----------
+    raw : instance of Raw
+        Data to add to the snirf file.
+    nirs : hpy5.Group
+        The root hdf5 nirs group to which the metadata should beadded.
+    """
+    metadata_tags = nirs.create_group("metaDataTags")
 
-        # Create 3d locs and store
-        srclocs = np.empty((len(np.unique(sources_sorted)), 3))
-        detlocs = np.empty((len(np.unique(detectors_sorted)), 3))
-        for i, src in enumerate(sources_sorted):
-            idx = sources.index(float(src))
-            srclocs[i, :] = raw.info['chs'][idx]['loc'][3:6]
-        for i, det in enumerate(detectors_sorted):
-            idx = detectors.index(float(det))
-            detlocs[i, :] = raw.info['chs'][idx]['loc'][6:9]
-        f.create_dataset("nirs/probe/sourcePos3D", data=srclocs)
-        f.create_dataset("nirs/probe/detectorPos3D", data=detlocs)
-        f.create_dataset("nirs/metaDataTags/LengthUnit",
-                         data=['m'.encode('UTF-8')])
+    # Store measurement and birth date
+    datestr = raw.info["meas_date"].strftime("%Y-%m-%d")
+    timestr = raw.info["meas_date"].strftime("%H:%M:%SZ")
+    birthday = datetime.date(*raw.info["subject_info"]["birthday"])
+    birthstr = birthday.strftime("%Y-%m-%d")
+    metadata_tags.create_dataset("MeasurementDate",
+                                 data=[_str_encode(datestr)])
+    metadata_tags.create_dataset("MeasurementTime",
+                                 data=[_str_encode(timestr)])
+    metadata_tags.create_dataset("DateOfBirth", data=[_str_encode(birthstr)])
 
-        # Prep data for storing each MNE channel as SNIRF measurementList
-        channels = ["measurementList" + str(idx + 1)
-                    for idx in range(len(raw.ch_names))]
-        sources = np.array([float(src) for src in sources])
-        detectors = np.array([float(det) for det in detectors])
-        sources_sorted = [float(src) for src in sources_sorted]
-        detectors_sorted = [float(det) for det in detectors_sorted]
-        wavelengths_sorted = [float(wve) for wve in wavelengths_sorted]
-        w = [float(wve) for wve in wavelengths]
-        wavelengths_index = [wavelengths_sorted.index(wve) + 1 for wve in w]
+    # Store demographic info
+    subject_id = raw.info["subject_info"]['first_name']
+    metadata_tags.create_dataset("SubjectID", data=[_str_encode(subject_id)])
 
-        for idx, ch in enumerate(channels):
-            f.create_dataset('nirs/data1/' + ch + '/sourceIndex',
-                             data=[sources_sorted.index(sources[idx]) + 1])
-            f.create_dataset('nirs/data1/' + ch + '/detectorIndex',
-                             data=[detectors_sorted.index(detectors[idx]) + 1])
-            f.create_dataset('nirs/data1/' + ch + '/wavelengthIndex',
-                             data=[wavelengths_index[idx]])
+    # Store the units of measurement
+    metadata_tags.create_dataset("LengthUnit", data=[_str_encode('m')])
 
-        # Store demographic info
-        subject_id = raw.info["subject_info"]['first_name']
-        f.create_dataset("nirs/metaDataTags/SubjectID",
-                         data=[subject_id.encode('UTF-8')])
+    # Add non standard (but allowed) custom metadata tags
+    if 'middle_name' in raw.info["subject_info"]:
+        middle_name = raw.info["subject_info"]['middle_name']
+        metadata_tags.create_dataset("middleName",
+                                     data=[_str_encode(middle_name)])
+    if 'last_name' in raw.info["subject_info"]:
+        last_name = raw.info["subject_info"]['last_name']
+        metadata_tags.create_dataset("lastName", data=[_str_encode(last_name)])
+    if 'sex' in raw.info["subject_info"]:
+        sex = str(int(raw.info["subject_info"]['sex']))
+        metadata_tags.create_dataset("sex", data=[_str_encode(sex)])
+    if raw.info['dig'] is not None:
+        coord_frame_id = int(raw.info['dig'][0].get("coord_frame"))
+        metadata_tags.create_dataset("MNE_coordFrame", data=[coord_frame_id])
 
-        # Convert MNE annotations to SNIRF stims
-        for desc in np.unique(raw.annotations.description):
-            key = "stim" + desc
-            trgs = np.where(raw.annotations.description == desc)[0]
-            stims = np.zeros((len(trgs), 3))
-            for idx, trg in enumerate(trgs):
-                stims[idx, :] = [raw.annotations.onset[trg], 5.0,
-                                 raw.annotations.duration[trg]]
-            f.create_dataset('/nirs/' + key + '/data', data=stims)
 
-        # Store probe landmarks
-        if raw.info['dig'] is not None:
-            diglocs = np.empty((len(raw.info['dig']), 3))
-            digname = list()
-            for idx, dig in enumerate(raw.info['dig']):
-                ident = re.match(r"\d+ \(FIFFV_POINT_(\w+)\)",
-                                 str(dig.get("ident")))
-                if ident is not None:
-                    digname.append(ident[1])
-                else:
-                    digname.append(str(dig.get("ident")))
-                diglocs[idx, :] = dig.get("r")
-            digname = [d.encode('UTF-8') for d in digname]
-            f.create_dataset("nirs/probe/landmarkPos3D", data=diglocs)
-            f.create_dataset("nirs/probe/landmarkLabels", data=digname)
-            # Add non standard (but allowed) custom metadata tags
-            f.create_dataset("nirs/metaDataTags/MNE_coordFrame",
-                             data=[int(raw.info['dig'][0].get("coord_frame"))])
+def _str_encode(str_val):
+    """Encode a string for use in an h5py Dataset.
 
-        # Add non standard (but allowed) custom metadata tags
-        if 'middle_name' in raw.info["subject_info"]:
-            mname = [raw.info["subject_info"]['middle_name'].encode('UTF-8')]
-            f.create_dataset("nirs/metaDataTags/middleName", data=mname)
-        if 'last_name' in raw.info["subject_info"]:
-            lname = [raw.info["subject_info"]['last_name'].encode('UTF-8')]
-            f.create_dataset("nirs/metaDataTags/lastName", data=lname)
-        if 'sex' in raw.info["subject_info"]:
-            sex = str(int(raw.info["subject_info"]['sex'])).encode('UTF-8')
-            f.create_dataset("nirs/metaDataTags/sex", data=[sex])
+    Parameters
+    ----------
+    str_val : str
+        The string to encode.
+    """
+    return str_val.encode('UTF-8')
+
+
+def _add_single_data_block(raw, nirs):
+    """Adds the data from raw to the nirs data1 group.
+
+    While SNIRF supports multiple datablocks, this writer only supports
+    a single data block named data1.
+
+    Parameters
+    ----------
+    raw : instance of Raw
+        Data to add to the snirf file.
+    nirs : hpy5.Group
+        The root hdf5 nirs group to which the data should be added.
+    """
+    data_block = nirs.create_group("data1")
+    data_block.create_dataset("dataTimeSeries", data=raw.get_data().T)
+    data_block.create_dataset("time", data=raw.times)
+
+    _add_measurement_lists(raw, data_block)
+
+
+def _add_measurement_lists(raw, data_block):
+    """Adds the measurement list groups to the nirs data1 group.
+
+    Parameters
+    ----------
+    raw : instance of Raw
+        Data to add to the snirf file.
+    data_block : hpy5.Group
+        The hdf5 data1 group to which the measurement lists should be added.
+    """
+    # Prep data for storing each MNE channel as SNIRF measurementList
+    data_block.create_dataset("measurementList1/dataType", data=1)
+
+    sources = _get_source_list(raw)
+    detectors = _get_detector_list(raw)
+    wavelengths = _get_wavelength_list(raw)
+
+    for idx, ch_name in enumerate(raw.ch_names, start=1):
+        ml_id = f'measurementList{idx}'
+        ch_group = data_block.require_group(ml_id)
+
+        source_idx = sources.index(_extract_source(ch_name)) + 1
+        detector_idx = detectors.index(_extract_detector(ch_name)) + 1
+        wavelength_idx = wavelengths.index(_extract_wavelength(ch_name)) + 1
+        ch_group.create_dataset("sourceIndex", data=[source_idx])
+        ch_group.create_dataset("detectorIndex", data=[detector_idx])
+        ch_group.create_dataset("wavelengthIndex", data=[wavelength_idx])
+
+
+def _add_probe_info(raw, nirs):
+    """Adds details of the probe to the nirs group.
+
+    Parameters
+    ----------
+    raw : instance of Raw
+        Data to add to the snirf file.
+    nirs : hpy5.Group
+        The root hdf5 nirs group to which the probe info should be added.
+    """
+    sources = _get_source_list(raw)
+    detectors = _get_detector_list(raw)
+    wavelengths = _get_wavelength_list(raw)
+
+    probe = nirs.create_group("probe")
+
+    # Store source/detector/wavelength info
+    encoded_source_labels = [_str_encode(f'S{src}') for src in sources]
+    encoded_detector_labels = [_str_encode(f'D{det}') for det in detectors]
+    probe.create_dataset("sourceLabels", data=encoded_source_labels)
+    probe.create_dataset("detectorLabels", data=encoded_detector_labels)
+    probe.create_dataset("wavelengths", data=wavelengths)
+
+    # Create 3d locs and store
+    ch_sources = [_extract_source(ch) for ch in raw.ch_names]
+    ch_detectors = [_extract_detector(ch) for ch in raw.ch_names]
+    srclocs = np.empty((len(sources), 3))
+    detlocs = np.empty((len(detectors), 3))
+    for i, src in enumerate(sources):
+        idx = ch_sources.index(float(src))
+        srclocs[i, :] = raw.info['chs'][idx]['loc'][3:6]
+    for i, det in enumerate(detectors):
+        idx = ch_detectors.index(float(det))
+        detlocs[i, :] = raw.info['chs'][idx]['loc'][6:9]
+    probe.create_dataset("sourcePos3D", data=srclocs)
+    probe.create_dataset("detectorPos3D", data=detlocs)
+
+    # Store probe landmarks
+    if raw.info['dig'] is not None:
+        _store_probe_landmarks(raw, probe)
+
+
+def _store_probe_landmarks(raw, probe):
+    """Adds the probe landmarks to the probe group.
+
+    Parameters
+    ----------
+    raw : instance of Raw
+        Data to add to the snirf file.
+    probe : hpy5.Group
+        The hdf5 probe group to which the landmark info should be added.
+    """
+    diglocs = np.empty((len(raw.info['dig']), 3))
+    digname = list()
+    for idx, dig in enumerate(raw.info['dig']):
+        ident = re.match(r"\d+ \(FIFFV_POINT_(\w+)\)",
+                         str(dig.get("ident")))
+        if ident is not None:
+            digname.append(ident[1])
+        else:
+            digname.append(str(dig.get("ident")))
+        diglocs[idx, :] = dig.get("r")
+    digname = [_str_encode(d) for d in digname]
+    probe.create_dataset("landmarkPos3D", data=diglocs)
+    probe.create_dataset("landmarkLabels", data=digname)
+
+
+def _add_stim_info(raw, nirs):
+    """Adds details of the stimuli to the nirs group.
+
+    Parameters
+    ----------
+    raw : instance of Raw
+        Data to add to the snirf file.
+    nirs : hpy5.Group
+        The root hdf5 nirs group to which the stimuli info should be added.
+    """
+    # Convert MNE annotations to SNIRF stims
+    for desc in np.unique(raw.annotations.description):
+        key = "stim" + desc
+        trgs = np.where(raw.annotations.description == desc)[0]
+        stims = np.zeros((len(trgs), 3))
+        for idx, trg in enumerate(trgs):
+            stims[idx, :] = [raw.annotations.onset[trg], 5.0,
+                             raw.annotations.duration[trg]]
+        stim_group = nirs.create_group(key)
+        stim_group.create_dataset('data', data=stims)
+
+
+def _get_source_list(raw):
+    ch_sources = [_extract_source(ch_name) for ch_name in raw.ch_names]
+    return list(sorted(set(ch_sources)))
+
+
+def _get_detector_list(raw):
+    ch_detectors = [_extract_detector(ch_name) for ch_name in raw.ch_names]
+    return list(sorted(set(ch_detectors)))
+
+
+def _get_wavelength_list(raw):
+    ch_wavelengths = [_extract_wavelength(ch_name) for ch_name in raw.ch_names]
+    return list(sorted(set(ch_wavelengths)))
+
+
+def _match_channel_pattern(channel_name):
+    rgx = r'^S(?P<source>\d+)_D(?P<detector>\d+) (?P<wavelength>\d+)$'
+    return re.fullmatch(rgx, channel_name)
+
+
+def _extract_source(channel_name):
+    return int(_match_channel_pattern(channel_name).group('source'))
+
+
+def _extract_detector(channel_name):
+    return int(_match_channel_pattern(channel_name).group('detector'))
+
+
+def _extract_wavelength(channel_name):
+    return float(_match_channel_pattern(channel_name).group('wavelength'))

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -288,7 +288,7 @@ def _match_channel_pattern(channel_name):
     rgx = r"^S(?P<source>\d+)_D(?P<detector>\d+) (?P<wavelength>\d+)$"
     match = re.fullmatch(rgx, channel_name)
     if match is None:
-        msg = f'channel name does not match expected pattern: {channel_name}'
+        msg = f"channel name does not match expected pattern: {channel_name}"
         raise ValueError(msg)
     return match
 

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -59,10 +59,10 @@ def test_snirf_write(fname, tmpdir):
             diffs += f'\n{line}'
     assert diffs == ''
 
-    verify_against_snirf_file_format_spec(test_file)
+    _verify_snirf_required_fields(test_file)
 
 
-def verify_against_snirf_file_format_spec(test_file):
+def _verify_snirf_required_fields(test_file):
     """Tests that all required fields are present.
 
     Uses Draft 3 of version 1.0 of the spec:

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -46,7 +46,7 @@ def test_snirf_write(fname, tmpdir):
     # Check data is the same
     assert_allclose(raw.get_data(), raw_orig.get_data())
 
-    assert abs(raw_orig.info["meas_date"] - raw.info["meas_date"]) < \
+    assert abs(raw_orig.info['meas_date'] - raw.info['meas_date']) < \
            datetime.timedelta(seconds=1)
 
     # Check info object is the same
@@ -69,47 +69,47 @@ def _verify_snirf_required_fields(test_file):
     https://github.com/fNIRS/snirf/blob/52de9a6724ddd0c9dcd36d8d11007895fed74205/snirf_specification.md
     """
     required_metadata_fields = [
-        "SubjectID", "MeasurementDate", "MeasurementTime",
-        "LengthUnit", "TimeUnit", "FrequencyUnit"
+        'SubjectID', 'MeasurementDate', 'MeasurementTime',
+        'LengthUnit', 'TimeUnit', 'FrequencyUnit'
     ]
     required_measurement_list_fields = [
-        "sourceIndex", "detectorIndex", "wavelengthIndex",
-        "dataType", "dataTypeIndex"
+        'sourceIndex', 'detectorIndex', 'wavelengthIndex',
+        'dataType', 'dataTypeIndex'
     ]
 
-    with h5py.File(test_file, "r") as h5:
+    with h5py.File(test_file, 'r') as h5:
         # Verify required base fields
-        assert "nirs" in h5
-        assert "formatVersion" in h5
+        assert 'nirs' in h5
+        assert 'formatVersion' in h5
 
         # Verify required metadata fields
-        assert "metaDataTags" in h5["/nirs"]
-        metadata = h5["/nirs/metaDataTags"]
+        assert 'metaDataTags' in h5['/nirs']
+        metadata = h5['/nirs/metaDataTags']
         for field in required_metadata_fields:
             assert field in metadata
 
         # Verify required data fields
-        assert "data1" in h5["/nirs"]
-        data1 = h5["/nirs/data1"]
-        assert "dataTimeSeries" in data1
-        assert "time" in data1
+        assert 'data1' in h5['/nirs']
+        data1 = h5['/nirs/data1']
+        assert 'dataTimeSeries' in data1
+        assert 'time' in data1
 
         # Verify required fields for each measurementList
         measurement_lists = [k for k in data1.keys()
-                             if k.startswith("measurementList")]
+                             if k.startswith('measurementList')]
         for ml in measurement_lists:
             for field in required_measurement_list_fields:
                 assert field in data1[ml]
 
         # Verify required fields for each stimulus
-        stims = [k for k in h5["/nirs"].keys() if k.startswith("stim")]
+        stims = [k for k in h5['/nirs'].keys() if k.startswith('stim')]
         for stim in stims:
-            assert "name" in h5["/nirs"][stim]
-            assert "data" in h5["/nirs"][stim]
+            assert 'name' in h5['/nirs'][stim]
+            assert 'data' in h5['/nirs'][stim]
 
         # Verify probe fields
-        assert "probe" in h5["/nirs"]
-        probe = h5["/nirs/probe"]
-        assert "wavelengths" in probe
-        assert "sourcePos3D" in probe or "sourcePos2D" in probe
-        assert "detectorPos3D" in probe or "detectorPos2D" in probe
+        assert 'probe' in h5['/nirs']
+        probe = h5['/nirs/probe']
+        assert 'wavelengths' in probe
+        assert 'sourcePos3D' in probe or 'sourcePos2D' in probe
+        assert 'detectorPos3D' in probe or 'detectorPos2D' in probe

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -11,7 +11,7 @@ import pytest
 from mne.datasets.testing import data_path, requires_testing_data
 from mne.utils import requires_h5py, object_diff
 from mne.io import read_raw_snirf, read_raw_nirx
-from mne_nirs.io.snirf import write_raw_snirf
+from mne_nirs.io.snirf import write_raw_snirf, SPEC_FORMAT_VERSION
 
 
 fname_nirx_15_0 = op.join(data_path(download=False),
@@ -60,6 +60,7 @@ def test_snirf_write(fname, tmpdir):
     assert diffs == ''
 
     _verify_snirf_required_fields(test_file)
+    _verify_snirf_version_str(test_file)
 
 
 def _verify_snirf_required_fields(test_file):
@@ -113,3 +114,11 @@ def _verify_snirf_required_fields(test_file):
         assert 'wavelengths' in probe
         assert 'sourcePos3D' in probe or 'sourcePos2D' in probe
         assert 'detectorPos3D' in probe or 'detectorPos2D' in probe
+
+
+def _verify_snirf_version_str(test_file):
+    """Verify that the version string contains the correct spec version."""
+    with h5py.File(test_file, 'r') as h5:
+        version_str = h5['/formatVersion'][0].decode('UTF-8')
+        expected_str = SPEC_FORMAT_VERSION
+        assert version_str == expected_str

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -69,47 +69,47 @@ def _verify_snirf_required_fields(test_file):
     https://github.com/fNIRS/snirf/blob/52de9a6724ddd0c9dcd36d8d11007895fed74205/snirf_specification.md
     """
     required_metadata_fields = [
-        'SubjectID', 'MeasurementDate', 'MeasurementTime',
-        'LengthUnit', 'TimeUnit', 'FrequencyUnit'
+        "SubjectID", "MeasurementDate", "MeasurementTime",
+        "LengthUnit", "TimeUnit", "FrequencyUnit"
     ]
     required_measurement_list_fields = [
-        'sourceIndex', 'detectorIndex', 'wavelengthIndex',
-        'dataType', 'dataTypeIndex'
+        "sourceIndex", "detectorIndex", "wavelengthIndex",
+        "dataType", "dataTypeIndex"
     ]
 
-    with h5py.File(test_file, 'r') as h5:
+    with h5py.File(test_file, "r") as h5:
         # Verify required base fields
-        assert 'nirs' in h5
-        assert 'formatVersion' in h5
+        assert "nirs" in h5
+        assert "formatVersion" in h5
 
         # Verify required metadata fields
-        assert 'metaDataTags' in h5['/nirs']
-        metadata = h5['/nirs/metaDataTags']
+        assert "metaDataTags" in h5["/nirs"]
+        metadata = h5["/nirs/metaDataTags"]
         for field in required_metadata_fields:
             assert field in metadata
 
         # Verify required data fields
-        assert 'data1' in h5['/nirs']
-        data1 = h5['/nirs/data1']
-        assert 'dataTimeSeries' in data1
-        assert 'time' in data1
+        assert "data1" in h5["/nirs"]
+        data1 = h5["/nirs/data1"]
+        assert "dataTimeSeries" in data1
+        assert "time" in data1
 
         # Verify required fields for each measurementList
         measurement_lists = [k for k in data1.keys()
-                             if k.startswith('measurementList')]
+                             if k.startswith("measurementList")]
         for ml in measurement_lists:
             for field in required_measurement_list_fields:
                 assert field in data1[ml]
 
         # Verify required fields for each stimulus
-        stims = [k for k in h5['/nirs'].keys() if k.startswith('stim')]
+        stims = [k for k in h5["/nirs"].keys() if k.startswith("stim")]
         for stim in stims:
-            assert 'name' in h5['/nirs'][stim]
-            assert 'data' in h5['/nirs'][stim]
+            assert "name" in h5["/nirs"][stim]
+            assert "data" in h5["/nirs"][stim]
 
         # Verify probe fields
-        assert 'probe' in h5['/nirs']
-        probe = h5['/nirs/probe']
-        assert 'wavelengths' in probe
-        assert 'sourcePos3D' in probe or 'sourcePos2D' in probe
-        assert 'detectorPos3D' in probe or 'detectorPos2D' in probe
+        assert "probe" in h5["/nirs"]
+        probe = h5["/nirs/probe"]
+        assert "wavelengths" in probe
+        assert "sourcePos3D" in probe or "sourcePos2D" in probe
+        assert "detectorPos3D" in probe or "detectorPos2D" in probe


### PR DESCRIPTION
Fix #317

This includes a fix for the inconsistencies between the snirf writer and the [snirf spec (Version 1.0 - Draft 3)](https://github.com/fNIRS/snirf/blob/master/snirf_specification.md#nirsidatajmeasurementlistk).

@rob-luke I will mark this as a draft PR because I have a few questions:

1. For the formatVersion it wasn't clear to me if there was a decision on version numbering prior to draft 4 when implemented would become v 1.0. So for now I've labeled it "1.0 - Draft 3". While that doesn't fit a clear convention, at least it should uniquely identify the spec, and can be updated to 1.0 once draft 4 is out. Is that ok for now, or would you prefer a different format?
1. I wasn't able to find an explicit time or frequency unit in the Raw object. Is it there and I missed it? Is there any specification on what the time or frequency units should be? For now I used 's' and 'Hz'.
1. the significance of dataTypeIndex isn't clear when using CW Amplitude. However, the spec gave an example where it set dataType=1 and dataTypeIndex=1 for CW Amplitude, so I copied that here.
https://github.com/fNIRS/snirf/blob/master/snirf_specification.md#nirsidatajmeasurementlistk
(after the moduleIndex sub-section)
1. SNIRF stim groups are now indexed sequentially from 1 to N (instead of using the description). The stim groups have a required 'name' parameter, while the only text component of the Annotations is 'description'. While it isn't an exact conceptual match, the description for the SNIRF 'name' field says: "This is a string describing the jth stimulus condition." Therefore I went ahead and mapped the Annotation description to the SNIRF stim name. Does that seem reasonable enough to you?

Finally, this includes a breaking change in the name of the stim groups: previously stim groups were named "stim1.0", "stim2.0", stim15.0", etc (not necessarily sequential), they are now sequentially named "stim1", "stim2", etc. I believe that the previous naming was incompatible with the spec so this is a bug fix, but this will be a breaking change for anyone relying on the previous naming convention.

Since the tests for the snirf writer rely on the MNE snirf reader which uses the existing stim group naming, the existing test breaks. I will submit a PR to MNE-Python as well (I already have a minimal fix locally), but we still need tests to pass here before we can merge this PR. Would you like to wait until the MNE PR is accepted and a new release is made? Or can we comment out the [annotations description check in `test_snirf_write`](https://github.com/mne-tools/mne-nirs/blob/832318363fb4e8a2002ae2cb82869d4522d41b08/mne_nirs/io/snirf/tests/test_snirf.py#L40-L41) for now (and create an issue to uncomment the annotations check once the next MNE version is released with the fix)?

