### PR TITLE
Set maximum long distance channel to 4.5 cm

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -14,6 +14,14 @@ Patch version changes indicate backward compatible bug fixes.
 
 To install a specific version of the library you would run ``pip install mne-nirs==0.0.6``, where ``0.0.6`` is the version you wish to install.
 
+v0.1.1 - dev
+------------
+
+API changes
+
+* Maximum source detector distance reduced from 5 to 4.5 cm when using :func:`mne_nirs.channels.get_long_channels`. By `Robert Luke`_.
+
+
 v0.1.0
 ------
 

--- a/mne_nirs/channels/_short.py
+++ b/mne_nirs/channels/_short.py
@@ -39,7 +39,7 @@ def get_short_channels(raw, max_dist=0.01):
     return short_chans
 
 
-def get_long_channels(raw, min_dist=0.01, max_dist=0.05):
+def get_long_channels(raw, min_dist=0.01, max_dist=0.045):
     """
     Return channels with a long source detector separation.
 

--- a/mne_nirs/channels/_short.py
+++ b/mne_nirs/channels/_short.py
@@ -10,14 +10,14 @@ import mne
 
 def get_short_channels(raw, max_dist=0.01):
     """
-    Return channels with a short source detector separation.
+    Return channels with a short source-detector separation.
 
     Parameters
     ----------
     raw : instance of Raw
-        The haemoglobin data.
+        Raw instance containing fNIRS data.
     max_dist : number
-        Maximum distance of returned channel (m).
+        Maximum distance of returned channels (m).
 
     Returns
     -------
@@ -39,18 +39,18 @@ def get_short_channels(raw, max_dist=0.01):
     return short_chans
 
 
-def get_long_channels(raw, min_dist=0.01, max_dist=0.045):
+def get_long_channels(raw, min_dist=0.015, max_dist=0.045):
     """
     Return channels with a long source detector separation.
 
     Parameters
     ----------
     raw : instance of Raw
-        The haemoglobin data.
+        Raw instance containing fNIRS data.
     min_dist : number
-        Minimum distance of returned channel.
+        Minimum distance of returned channels (m).
     max_dist : number
-        Maximum distance of returned channel.
+        Maximum distance of returned channels (m).
 
     Returns
     -------


### PR DESCRIPTION
Based on results from lab meeting and from my own data, I see a decrease in data quality for channels with a distance above 4.5 cm. Below is one figure demonstrating that at 5.3 cm the data quality drops. Internal results showed a similar drop above 4.5 cm.

![image](https://user-images.githubusercontent.com/748691/128322603-8f2efa21-ff55-4f69-884f-d2c75803ae45.png)
