### PR TITLE
Use two .bib files. One from MNE-Python, one for NIRS

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -123,7 +123,7 @@ numpydoc_validation_exclude = {  # set of regex
 
 
 # sphinxcontrib-bibtex
-bibtex_bibfiles = ['./references.bib']
+bibtex_bibfiles = ['./references.bib', './references-nirs.bib']
 bibtex_style = 'unsrt'
 bibtex_footbibliography_header = ''
 

--- a/doc/references-nirs.bib
+++ b/doc/references-nirs.bib
@@ -1,0 +1,47 @@
+% References in addition to what is included with MNE-Python.
+% references.bib is a direct copy from MNE-Python.
+% references-nirs.bib is papers not included in the above.
+
+@article{fabbri2004optical,
+  title={Optical measurements of absorption changes in two-layered diffusive media},
+  author={Fabbri, Francesco and Sassaroli, Angelo and Henry, Michael E and Fantini, Sergio},
+  journal={Physics in Medicine \& Biology},
+  volume={49},
+  number={7},
+  pages={1183},
+  year={2004},
+  publisher={IOP Publishing}
+}
+
+@article{saager2005direct,
+  title={Direct characterization and removal of interfering absorption trends in two-layer turbid media},
+  author={Saager, Rolf B and Berger, Andrew J},
+  journal={JOSA A},
+  volume={22},
+  number={9},
+  pages={1874--1882},
+  year={2005},
+  publisher={Optical Society of America}
+}
+
+@article{scholkmann2014measuring,
+  title={Measuring tissue hemodynamics and oxygenation by continuous-wave functional near-infrared spectroscopy—how robust are the different calculation methods against movement artifacts?},
+  author={Scholkmann, Felix and Metz, Andreas Jaakko and Wolf, Martin},
+  journal={Physiological measurement},
+  volume={35},
+  number={4},
+  pages={717},
+  year={2014},
+  publisher={IOP Publishing}
+}
+
+@article{cui2010functional,
+  title={Functional near infrared spectroscopy (NIRS) signal improvement based on negative correlation between oxygenated and deoxygenated hemoglobin dynamics},
+  author={Cui, Xu and Bray, Signe and Reiss, Allan L},
+  journal={Neuroimage},
+  volume={49},
+  number={4},
+  pages={3039--3046},
+  year={2010},
+  publisher={Elsevier}
+}

--- a/doc/references-nirs.bib
+++ b/doc/references-nirs.bib
@@ -1,3 +1,5 @@
+% Encoding: UTF-8
+%
 % References in addition to what is included with MNE-Python.
 % references.bib is a direct copy from MNE-Python.
 % references-nirs.bib is papers not included in the above.

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1314,7 +1314,8 @@
   shorttitle = {Standardized Low-Resolution Brain Electromagnetic Tomography ({{sLORETA}})},
   title = {Standardized Low-Resolution Brain Electromagnetic Tomography ({{sLORETA}}): Technical Details},
   volume = {24},
-  year = {2002}
+  year = {2002},
+  url = {https://pubmed.ncbi.nlm.nih.gov/12575463/}
 }
 
 @article{Pascual-Marqui2011,
@@ -1389,11 +1390,13 @@
 @article{pollonini2014auditory,
   title={Auditory cortex activation to natural speech and simulated cochlear implant speech measured with functional near-infrared spectroscopy},
   author={Pollonini, Luca and Olds, Cristen and Abaya, Homer and Bortfeld, Heather and Beauchamp, Michael S and Oghalai, John S},
-  journal={Hearing research},
+  journal={Hearing Research},
   volume={309},
   pages={84--93},
   year={2014},
-  publisher={Elsevier}
+  publisher={Elsevier},
+  pmid={24342740},
+  doi={10.1016/j.heares.2013.11.007}
 }
 
 @article{RidgwayEtAl2012,
@@ -2125,48 +2128,4 @@
   publisher = {PMLR},
   pdf = {http://proceedings.mlr.press/v130/bertrand21a/bertrand21a.pdf},
   url = {http://proceedings.mlr.press/v130/bertrand21a.html}
-}
-
-@article{fabbri2004optical,
-  title={Optical measurements of absorption changes in two-layered diffusive media},
-  author={Fabbri, Francesco and Sassaroli, Angelo and Henry, Michael E and Fantini, Sergio},
-  journal={Physics in Medicine \& Biology},
-  volume={49},
-  number={7},
-  pages={1183},
-  year={2004},
-  publisher={IOP Publishing}
-}
-
-@article{saager2005direct,
-  title={Direct characterization and removal of interfering absorption trends in two-layer turbid media},
-  author={Saager, Rolf B and Berger, Andrew J},
-  journal={JOSA A},
-  volume={22},
-  number={9},
-  pages={1874--1882},
-  year={2005},
-  publisher={Optical Society of America}
-}
-
-@article{scholkmann2014measuring,
-  title={Measuring tissue hemodynamics and oxygenation by continuous-wave functional near-infrared spectroscopy—how robust are the different calculation methods against movement artifacts?},
-  author={Scholkmann, Felix and Metz, Andreas Jaakko and Wolf, Martin},
-  journal={Physiological measurement},
-  volume={35},
-  number={4},
-  pages={717},
-  year={2014},
-  publisher={IOP Publishing}
-}
-
-@article{cui2010functional,
-  title={Functional near infrared spectroscopy (NIRS) signal improvement based on negative correlation between oxygenated and deoxygenated hemoglobin dynamics},
-  author={Cui, Xu and Bray, Signe and Reiss, Allan L},
-  journal={Neuroimage},
-  volume={49},
-  number={4},
-  pages={3039--3046},
-  year={2010},
-  publisher={Elsevier}
 }


### PR DESCRIPTION
To minimise work for me when new references are added. And easier to keep the existing references in sync with MNE as I can just copy and paste without edit.