### PR TITLE
Enable version banner

### DIFF
--- a/.github/workflows/NumpyDoc_PR.yml
+++ b/.github/workflows/NumpyDoc_PR.yml
@@ -11,6 +11,7 @@ jobs:
   numpydoc:
     name: 'numpydoc'
     runs-on: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, '[skip docs]')"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/SphinxBuild.yml
+++ b/.github/workflows/SphinxBuild.yml
@@ -12,6 +12,7 @@ jobs:
   job:
     name: 'docs and push'
     runs-on: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, '[skip docs]')"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/SphinxBuild_PR.yml
+++ b/.github/workflows/SphinxBuild_PR.yml
@@ -8,6 +8,7 @@ jobs:
   job:
     name: 'docs'
     runs-on: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, '[skip docs]')"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -17,6 +17,7 @@ jobs:
   job:
     name: 'py3.8'
     runs-on: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, '[skip tests]')"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/linux_pip.yml
+++ b/.github/workflows/linux_pip.yml
@@ -17,6 +17,7 @@ jobs:
   job:
     name: 'py3.8'
     runs-on: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, '[skip tests]')"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/linux_pip_examples.yml
+++ b/.github/workflows/linux_pip_examples.yml
@@ -13,6 +13,7 @@ jobs:
   job:
     name: 'py3.8'
     runs-on: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, '[skip tests]')"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/macos_conda.yml
+++ b/.github/workflows/macos_conda.yml
@@ -16,6 +16,7 @@ jobs:
   job:
     name: 'py3.8'
     runs-on: macos-latest
+    if: "!contains(github.event.head_commit.message, '[skip tests]')"
     defaults:
       run:
         shell: bash

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -3,8 +3,15 @@
 <p>
   <strong>
     <p style="border:3px; border-style:solid; border-color:#FF0000; padding: 1em;">
-      <h3>Latest Version: {{ latest_version.name }}</h3>
-      <h3>Current Version: {{ current_version.name }}</h3>
+      {% if current_version.is_released %}
+        Released version
+        Current Version: {{ current_version.name }}
+        Released: {{ current_version.is_released }}
+      {% else %}
+        Development version
+        Current Version: {{ current_version.name }}
+        Released: {{ current_version.is_released }}
+      {% endif %}
     </p>
   </strong>
 </p>

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -5,7 +5,7 @@
     {% if current_version.is_released %}
       <p style="border:3px; border-style:solid; border-color:#ad6228; padding: 1em;">
         You are currently reading the MNE-NIRS documentation for version {{ current_version.name }}.
-        To view the latest development version <a href="https://mne.tools/mne-nirs/main/index.html">{{click here.}}</a>
+        To view the latest development version <a href="https://mne.tools/mne-nirs/main/index.html">click here.</a>
       </p>
     {% else %}
       <p style="border:3px; border-style:solid; border-color:#24872b; padding: 1em;">

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -2,17 +2,18 @@
 {% block body %}
 <p>
   <strong>
-    <p style="border:3px; border-style:solid; border-color:#FF0000; padding: 1em;">
-      {% if current_version.is_released %}
-        Released version
-        Current Version: {{ current_version.name }}
-        Released: {{ current_version.is_released }}
-      {% else %}
-        Development version
-        Current Version: {{ current_version.name }}
-        Released: {{ current_version.is_released }}
-      {% endif %}
-    </p>
+    {% if current_version.is_released %}
+      <p style="border:3px; border-style:solid; border-color:#ad6228; padding: 1em;">
+        You are currently reading the MNE-NIRS documentation for version {{ current_version.name }}.
+        To view the latest development version <a href="https://mne.tools/mne-nirs/main/index.html">{{click here.}}</a>
+      </p>
+    {% else %}
+      <p style="border:3px; border-style:solid; border-color:#24872b; padding: 1em;">
+        You are currently reading the latest MNE-NIRS documentation for the development version.
+        If you wish to view the documentation associated with a stable release,
+        use the blue dropdown menu in the top right corner of the page.
+      </p>
+    {% endif %}
   </strong>
 </p>
 {{ super() }}

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -4,12 +4,12 @@
   <strong>
     {% if current_version.is_released %}
       <p style="border:3px; border-style:solid; border-color:#ad6228; padding: 1em;">
-        You are currently reading the MNE-NIRS documentation for version {{ current_version.name }}.
-        To view the latest development version <a href="https://mne.tools/mne-nirs/main/index.html">click here.</a>
+        You are currently reading the MNE-NIRS documentation for release version {{ current_version.name }}.
+        To view the documentation for the latest development version <a href="https://mne.tools/mne-nirs/main/index.html">click here.</a>
       </p>
     {% else %}
       <p style="border:3px; border-style:solid; border-color:#24872b; padding: 1em;">
-        You are currently reading the latest MNE-NIRS documentation for the development version.
+        You are currently reading the latest MNE-NIRS development version documentation.
         If you wish to view the documentation associated with a stable release,
         use the blue dropdown menu in the top right corner of the page.
       </p>

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -3,18 +3,7 @@
 <p>
   <strong>
     <p style="border:3px; border-style:solid; border-color:#FF0000; padding: 1em;">
-    {% if current_version.is_released %}
-    You are reading version ({{current_version.name}}) of the documentation associated with a release.
-    Releases provide a snapshot of the software from a specific instance in time,
-    allowing you to always revert to a working version of the code and view the associated documentation.
-    Releases are created at instances when the code is considered stable and feature complete.
-    Whereas, the main branch contains the latest features and newest version of the code.
-    To view the latest up-to-date documentation for this project,
-    please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
-    {% else %}
-    You're reading the documentation for a development version.
-    If you prefer to read the documentation from the last stable release, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
-    {% endif %}
+      Test
     </p>
   </strong>
 </p>

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -3,7 +3,8 @@
 <p>
   <strong>
     <p style="border:3px; border-style:solid; border-color:#FF0000; padding: 1em;">
-      Test
+      <h3>Latest Version: {{ latest_version.name }}</h3>
+      <h3>Current Version: {{ current_version.name }}</h3>
     </p>
   </strong>
 </p>

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -1,24 +1,22 @@
 {% extends "!page.html" %}
 {% block body %}
-{% if current_version and latest_version and current_version != latest_version %}
 <p>
   <strong>
     <p style="border:3px; border-style:solid; border-color:#FF0000; padding: 1em;">
     {% if current_version.is_released %}
-    You are reading a version ({{current_version.name}}) of the documentation associated with a release.
+    You are reading version ({{current_version.name}}) of the documentation associated with a release.
     Releases provide a snapshot of the software from a specific instance in time,
-    allowing you to always revert to a working version of the code.
+    allowing you to always revert to a working version of the code and view the associated documentation.
     Releases are created at instances when the code is considered stable and feature complete.
     Whereas, the main branch contains the latest features and newest version of the code.
     To view the latest up-to-date documentation for this project,
     please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
     {% else %}
     You're reading the documentation for a development version.
-    For the latest released version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
+    If you prefer to read the documentation from the last stable release, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
     {% endif %}
     </p>
   </strong>
 </p>
-{% endif %}
 {{ super() }}
 {% endblock %}%

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,10 +54,10 @@ extensions = [
 ]
 
 smv_branch_whitelist = r'^(?!refs/heads/).*$'
-# smv_tag_whitelist = r'^v\d+\.\d+.\d+$'
+smv_tag_whitelist = r'^v\d+\.\d+.\d+$'
 # They say to set this to None, but then Sphinx complains about it not being
 # a string, so let's just use a regex that should lead to no tags
-smv_tag_whitelist = 'ignore all tags'
+# smv_tag_whitelist = 'ignore all tags'
 # Mark vX.Y.Z as releases
 smv_released_pattern = r'^.*v.*$'
 


### PR DESCRIPTION
#### Reference issue
At some point the version banner disappeared, I am not sure when this happened.

Edit: The issue seems to be that the variable `latest_version` is not being populated by sphinx-multiversion when run on the CIs. This may be due to there only being a single branch being built (I only rebuild all docs when a new release is made). So have rewritten the if else statements to avoid this missing variable.