### PR TITLE
Use environmental variable to set multi version sphinx tag list

### DIFF
--- a/.github/workflows/SphinxBuild_PR.yml
+++ b/.github/workflows/SphinxBuild_PR.yml
@@ -1,4 +1,4 @@
-name: "docs"
+name: "PR Docs"
 on:
 - pull_request
 
@@ -20,6 +20,7 @@ jobs:
       PYTHONUNBUFFERED: '1'
       PYTHON_VERSION: '3.9'
       MNE_3D_BACKEND: 'pyvistaqt'
+      SMV_TAG_WHITELIST: 'ignore all tags'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ from mne_nirs import __version__  # noqa: E402
 from mne.tests.test_docstring_parameters import error_ignores
 
 
-smv_tag_whitelist = os.getenv('SMV_TAG_WHITELIST', r'^v\d+\.\d+.\d+$'))
+smv_tag_whitelist = os.getenv('SMV_TAG_WHITELIST', r'^v\d+\.\d+.\d+$')
 
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,6 +27,9 @@ from mne_nirs import __version__  # noqa: E402
 from mne.tests.test_docstring_parameters import error_ignores
 
 
+smv_tag_whitelist = os.getenv('SMV_TAG_WHITELIST', r'^v\d+\.\d+.\d+$'))
+
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -57,7 +60,7 @@ smv_branch_whitelist = r'^(?!refs/heads/).*$'
 # smv_tag_whitelist = r'^v\d+\.\d+.\d+$'
 # They say to set this to None, but then Sphinx complains about it not being
 # a string, so let's just use a regex that should lead to no tags
-smv_tag_whitelist = 'ignore all tags'
+# smv_tag_whitelist = 'ignore all tags'
 # Mark vX.Y.Z as releases
 smv_released_pattern = r'^.*v.*$'
 


### PR DESCRIPTION
Still working on #375 

This PR adds an environmental variable that controls which tag versions sphinx multi version will build. For PRs only the PR will be built. When committed to main the entire history will be regenerated. Ideally we would only build the latest but cant use the history remover and the keep files option due to this bug https://github.com/peaceiris/actions-gh-pages/issues/455