### PR TITLE
Use MNE-Python fetch_dataset function

### DIFF
--- a/mne_nirs/datasets/fnirs_motor_group/fnirs_motor_group.py
+++ b/mne_nirs/datasets/fnirs_motor_group/fnirs_motor_group.py
@@ -30,11 +30,10 @@ def data_path(path=None, force_update=False, update_path=True, download=True,
         config_key='MNE_DATASETS_FNIRSMOTORGROUP_PATH',
     )
 
-    dpath = fetch_dataset(dataset_params, processor=pooch.Unzip(
-        extract_dir="./fNIRS-motor-group"),
-                         path=path,
-                         force_update=force_update, update_path=update_path,
-                         download=download)
+    dpath = fetch_dataset(dataset_params, path=path, force_update=force_update,
+                          update_path=update_path, download=download,
+                          processor=pooch.Unzip(
+                              extract_dir="./fNIRS-motor-group"))
 
     # Do some wrangling to deal with nested directories
     bad_name = os.path.join(dpath, 'BIDS-NIRS-Tapping-master')

--- a/mne_nirs/datasets/fnirs_motor_group/fnirs_motor_group.py
+++ b/mne_nirs/datasets/fnirs_motor_group/fnirs_motor_group.py
@@ -4,14 +4,11 @@
 # This downloads my fnirs group tapping data. Once BIDS is finalised
 # and the dataset complies I will add this to the MNE-Python library.
 
-import os
-import os.path as op
 from functools import partial
-import shutil
 
 from mne.utils import verbose
-from mne.datasets.utils import (has_dataset)
-from mne.datasets.utils import _get_path
+from mne.datasets.utils import has_dataset
+from mne.datasets import fetch_dataset
 
 has_fnirs_motor_group_data = partial(has_dataset, name='fnirs_motor_group')
 
@@ -19,34 +16,14 @@ has_fnirs_motor_group_data = partial(has_dataset, name='fnirs_motor_group')
 @verbose
 def data_path(path=None, force_update=False, update_path=True, download=True,
               verbose=None):  # noqa: D103
-    # TODO: all of the arguments to the function are being ignored!
-    import pooch
 
-    datapath = _get_path(None, 'MNE_DATASETS_SAMPLE_PATH', None)
-    foldername = 'fNIRS-motor-group'
-    archive_name = 'BIDS-NIRS-Tapping-master.zip'
-    urls = {archive_name:
-            'https://github.com/rob-luke/BIDS-NIRS-Tapping/archive/master.zip'}
-    hashes = {archive_name: 'md5:8b1a09e4af64ec66426b9c70c07a5594'}
-
-    fetcher = pooch.create(
-        path=datapath,
-        base_url='',    # Full URLs are given in the `urls` dict.
-        version=None,   # Data versioning is decoupled from MNE-Python version.
-        urls=urls,
-        retry_if_failed=2,  # 2 retries = 3 total attempts
-        registry=hashes
+    dataset_params = dict(
+        archive_name='BIDS-NIRS-Tapping-master.zip',
+        hash='md5:d2b32a03601c9882aef534e22ad237ab',
+        url='https://github.com/rob-luke/BIDS-NIRS-Tapping/archive/master.zip',
+        folder_name='fNIRS-motor-group',
     )
 
-    # fetch and unpack the data
-    archive_name = 'BIDS-NIRS-Tapping-master.zip'
-    downloader = pooch.HTTPDownloader(progressbar=True)
-    unzip = pooch.Unzip(extract_dir=datapath)
-    fetcher.fetch(fname=archive_name, downloader=downloader, processor=unzip)
-    # after unpacking, remove the archive file
-    os.remove(op.join(datapath, archive_name))
-    if op.isdir(op.join(datapath, foldername)):
-        return op.join(datapath, foldername)
-    else:
-        return shutil.move(op.join(datapath, archive_name[:-4]),
-                           op.join(datapath, foldername))
+    return fetch_dataset(dataset_params, processor='unzip', path=path,
+                         force_update=force_update, update_path=update_path,
+                         download=download)

--- a/mne_nirs/datasets/fnirs_motor_group/fnirs_motor_group.py
+++ b/mne_nirs/datasets/fnirs_motor_group/fnirs_motor_group.py
@@ -4,6 +4,9 @@
 # This downloads my fnirs group tapping data. Once BIDS is finalised
 # and the dataset complies I will add this to the MNE-Python library.
 
+import os
+import tempfile
+import shutil
 import pooch
 from functools import partial
 
@@ -27,8 +30,18 @@ def data_path(path=None, force_update=False, update_path=True, download=True,
         config_key='MNE_DATASETS_FNIRSMOTORGROUP_PATH',
     )
 
-    return fetch_dataset(dataset_params, processor=pooch.Unzip(
+    dpath = fetch_dataset(dataset_params, processor=pooch.Unzip(
         extract_dir="./fNIRS-motor-group"),
                          path=path,
                          force_update=force_update, update_path=update_path,
                          download=download)
+
+    # Do some wrangling to deal with nested directories
+    bad_name = os.path.join(dpath, 'BIDS-NIRS-Tapping-master')
+    if os.path.isdir(bad_name):
+        tmppath = tempfile.mkdtemp()
+        os.rename(bad_name, tmppath)
+        shutil.rmtree(dpath)
+        os.rename(tmppath, dpath)
+
+    return dpath

--- a/mne_nirs/datasets/fnirs_motor_group/fnirs_motor_group.py
+++ b/mne_nirs/datasets/fnirs_motor_group/fnirs_motor_group.py
@@ -4,6 +4,7 @@
 # This downloads my fnirs group tapping data. Once BIDS is finalised
 # and the dataset complies I will add this to the MNE-Python library.
 
+import pooch
 from functools import partial
 
 from mne.utils import verbose
@@ -22,8 +23,12 @@ def data_path(path=None, force_update=False, update_path=True, download=True,
         hash='md5:d2b32a03601c9882aef534e22ad237ab',
         url='https://github.com/rob-luke/BIDS-NIRS-Tapping/archive/master.zip',
         folder_name='fNIRS-motor-group',
+        dataset_name='fnirs_motor_group',
+        config_key='MNE_DATASETS_FNIRSMOTORGROUP_PATH',
     )
 
-    return fetch_dataset(dataset_params, processor='unzip', path=path,
+    return fetch_dataset(dataset_params, processor=pooch.Unzip(
+        extract_dir="./fNIRS-motor-group"),
+                         path=path,
                          force_update=force_update, update_path=update_path,
                          download=download)

--- a/mne_nirs/datasets/fnirs_motor_group/tests/test_dataset_tap.py
+++ b/mne_nirs/datasets/fnirs_motor_group/tests/test_dataset_tap.py
@@ -7,6 +7,10 @@ import mne_nirs
 
 def test_dataset_tapping_group():
     datapath = mne_nirs.datasets.fnirs_motor_group.data_path()
-    print(datapath)
+    assert op.isdir(datapath)
+    assert op.isdir(op.join(datapath, "sub-01"))
+
+    # First pass downloaded, check that second pass of access works
+    datapath = mne_nirs.datasets.fnirs_motor_group.data_path()
     assert op.isdir(datapath)
     assert op.isdir(op.join(datapath, "sub-01"))

--- a/mne_nirs/datasets/fnirs_motor_group/tests/test_dataset_tap.py
+++ b/mne_nirs/datasets/fnirs_motor_group/tests/test_dataset_tap.py
@@ -7,5 +7,6 @@ import mne_nirs
 
 def test_dataset_tapping_group():
     datapath = mne_nirs.datasets.fnirs_motor_group.data_path()
+    print(datapath)
     assert op.isdir(datapath)
     assert op.isdir(op.join(datapath, "sub-01"))


### PR DESCRIPTION
#### Reference issue
Following https://github.com/mne-tools/mne-python/pull/9763 and #388 this correctly addresses the downloading of datasets in MNE-NIRS

#### What does this implement/fix?
Use the new `fetch_dataset` function from MNE-Python
