### PR TITLE
Automatically sanitse annotation names that arent compatible with nilearn

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -31,6 +31,11 @@ Enhancements
 * Add :func:`mne_nirs.io.fold_channel_specificity`. By `Robert Luke`_.
 
 
+Fixes
+
+* Prepend a character to event names that are number only to comply with nilearn criteria for design matrix column names. By `Robert Luke`_.
+
+
 v0.1.1
 ------
 

--- a/examples/general/plot_11_hrf_measured.py
+++ b/examples/general/plot_11_hrf_measured.py
@@ -239,7 +239,7 @@ fig = plot_design_matrix(design_matrix, ax=ax1)
 
 s = mne_nirs.experimental_design.create_boxcar(raw_intensity, stim_dur=5.0)
 plt.plot(raw_intensity.times, s[:, 1])
-plt.plot(design_matrix['Tapping/Left'])
+plt.plot(design_matrix['Tapping_Left'])
 plt.xlim(180, 300)
 plt.legend(["Stimulus", "Expected Response"])
 plt.xlabel("Time (s)")
@@ -336,7 +336,7 @@ glm_est.scatter()
 # negative of HbO as expected.
 
 glm_est = run_glm(raw_haemo, design_matrix)
-glm_est.plot_topo(conditions=['Tapping/Left', 'Tapping/Right'])
+glm_est.plot_topo(conditions=['Tapping/Left', 'Tapping_Right'])
 
 
 # %%
@@ -364,7 +364,7 @@ glm_est.plot_topo(conditions=['Tapping/Left', 'Tapping/Right'])
 fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(10, 6), gridspec_kw=dict(width_ratios=[0.92, 1]))
 
 glm_hbo = glm_est.copy().pick(picks="hbo")
-conditions = ['Tapping/Right']
+conditions = ['Tapping_Right']
 
 glm_hbo.plot_topo(axes=axes[0], colorbar=False, conditions=conditions)
 
@@ -380,7 +380,7 @@ axes[1].set_title("Hemispheres plotted independently")
 # Another way to view the data is to project the GLM estimates to the nearest
 # cortical surface
 
-glm_est.copy().surface_projection(condition="Tapping/Right", view="dorsal", chroma="hbo")
+glm_est.copy().surface_projection(condition="Tapping_Right", view="dorsal", chroma="hbo")
 
 
 # %%
@@ -412,7 +412,7 @@ right = [[5, 5], [5, 6], [5, 7], [6, 5], [6, 7],
 groups = dict(Left_ROI=picks_pair_to_idx(raw_haemo, left),
               Right_ROI=picks_pair_to_idx(raw_haemo, right))
 
-conditions = ['Control', 'Tapping/Left', 'Tapping/Right']
+conditions = ['Control', 'Tapping_Left', 'Tapping_Right']
 
 df = glm_est.to_dataframe_region_of_interest(groups, conditions)
 
@@ -439,7 +439,7 @@ df
 contrast_matrix = np.eye(design_matrix.shape[1])
 basic_conts = dict([(column, contrast_matrix[i])
                    for i, column in enumerate(design_matrix.columns)])
-contrast_LvR = basic_conts['Tapping/Left'] - basic_conts['Tapping/Right']
+contrast_LvR = basic_conts['Tapping_Left'] - basic_conts['Tapping_Right']
 
 contrast = glm_est.compute_contrast(contrast_LvR)
 contrast.plot_topo()
@@ -474,7 +474,7 @@ df = glm_est.to_dataframe()
 # the tapping, but we do expect 5% or less for the false positive rate.
 
 (df
- .query('Condition in ["Control", "Tapping/Left", "Tapping/Right"]')
+ .query('Condition in ["Control", "Tapping_Left", "Tapping_Right"]')
  .groupby(['Condition', 'Chroma'])
  .agg(['mean'])
  .drop(['df', 'mse', 'p_value', 't'], 1)

--- a/examples/general/plot_11_hrf_measured.py
+++ b/examples/general/plot_11_hrf_measured.py
@@ -239,7 +239,7 @@ fig = plot_design_matrix(design_matrix, ax=ax1)
 
 s = mne_nirs.experimental_design.create_boxcar(raw_intensity, stim_dur=5.0)
 plt.plot(raw_intensity.times, s[:, 1])
-plt.plot(design_matrix['Tapping_Left'])
+plt.plot(design_matrix['Tapping___Left'])
 plt.xlim(180, 300)
 plt.legend(["Stimulus", "Expected Response"])
 plt.xlabel("Time (s)")
@@ -336,7 +336,7 @@ glm_est.scatter()
 # negative of HbO as expected.
 
 glm_est = run_glm(raw_haemo, design_matrix)
-glm_est.plot_topo(conditions=['Tapping/Left', 'Tapping_Right'])
+glm_est.plot_topo(conditions=['Tapping___Left', 'Tapping___Right'])
 
 
 # %%
@@ -364,7 +364,7 @@ glm_est.plot_topo(conditions=['Tapping/Left', 'Tapping_Right'])
 fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(10, 6), gridspec_kw=dict(width_ratios=[0.92, 1]))
 
 glm_hbo = glm_est.copy().pick(picks="hbo")
-conditions = ['Tapping_Right']
+conditions = ['Tapping___Right']
 
 glm_hbo.plot_topo(axes=axes[0], colorbar=False, conditions=conditions)
 
@@ -380,7 +380,7 @@ axes[1].set_title("Hemispheres plotted independently")
 # Another way to view the data is to project the GLM estimates to the nearest
 # cortical surface
 
-glm_est.copy().surface_projection(condition="Tapping_Right", view="dorsal", chroma="hbo")
+glm_est.copy().surface_projection(condition="Tapping___Right", view="dorsal", chroma="hbo")
 
 
 # %%

--- a/mne_nirs/experimental_design/_experimental_design.py
+++ b/mne_nirs/experimental_design/_experimental_design.py
@@ -86,6 +86,12 @@ def make_first_level_design_matrix(raw, stim_dur=1.,
     conditions = raw.annotations.description
     onsets = raw.annotations.onset - raw.first_time
     duration = stim_dur * np.ones(len(conditions))
+    for cidx, condition in enumerate(conditions):
+        if not condition.isidentifier():
+            # Need to ensure we have valid identifiers for nilearn
+            # so we prepend a t to refer to a trigger identifier
+            conditions[cidx] = f"t_{condition}"
+
     events = DataFrame({'trial_type': conditions,
                         'onset': onsets,
                         'duration': duration})

--- a/mne_nirs/experimental_design/_experimental_design.py
+++ b/mne_nirs/experimental_design/_experimental_design.py
@@ -84,7 +84,7 @@ def make_first_level_design_matrix(raw, stim_dur=1.,
     frame_times = raw.times
 
     # Create events for nilearn
-    conditions = raw.annotations.description
+    conditions = list(raw.annotations.description)
     onsets = raw.annotations.onset - raw.first_time
     duration = stim_dur * np.ones(len(conditions))
 

--- a/mne_nirs/experimental_design/tests/test_experimental_design.py
+++ b/mne_nirs/experimental_design/tests/test_experimental_design.py
@@ -9,6 +9,8 @@ import mne_nirs
 import numpy as np
 from mne_nirs.experimental_design import make_first_level_design_matrix, \
     longest_inter_annotation_interval, drift_high_pass
+from mne_nirs.experimental_design._experimental_design import (
+    _sanitise_names_for_nilearn, _unsanitise_names_for_nilearn)
 from mne_nirs.simulation import simulate_nirs_raw
 
 
@@ -102,3 +104,30 @@ def test_high_pass_helpers():
     assert lisi <= 40
     assert drift_high_pass(raw) >= 1 / (40 * 2)
     assert drift_high_pass(raw) <= 1 / (20 * 2)
+
+
+def test_name_sanitisation_for_nilearn():
+    # Test the helpers give reasonable values
+
+    assert _sanitise_names_for_nilearn('2.0').isidentifier()
+    assert _sanitise_names_for_nilearn('23.0').isidentifier()
+    assert _sanitise_names_for_nilearn('3').isidentifier()
+    assert _sanitise_names_for_nilearn('Audio/Left').isidentifier()
+    assert _sanitise_names_for_nilearn('Audio/Left/F').isidentifier()
+
+    assert _sanitise_names_for_nilearn('2.0') == "t_2_0"
+    assert _sanitise_names_for_nilearn('23.0') == "t_23_0"
+    assert _sanitise_names_for_nilearn('3') == "t_3"
+    assert _sanitise_names_for_nilearn('Audio/Left') == "Audio___Left"
+    assert _sanitise_names_for_nilearn('Audio/Left/F') == "Audio___Left___F"
+
+    assert _unsanitise_names_for_nilearn(
+        _sanitise_names_for_nilearn('2.0')) == "2.0"
+    assert _unsanitise_names_for_nilearn(
+        _sanitise_names_for_nilearn('23.0')) == "23.0"
+    assert _unsanitise_names_for_nilearn(
+        _sanitise_names_for_nilearn('3')) == "3"
+    assert _unsanitise_names_for_nilearn(
+        _sanitise_names_for_nilearn('Audio/Left')) == "Audio/Left"
+    assert _unsanitise_names_for_nilearn(
+        _sanitise_names_for_nilearn('Audio/Left/F')) == "Audio/Left/F"

--- a/mne_nirs/statistics/tests/test_glm_type.py
+++ b/mne_nirs/statistics/tests/test_glm_type.py
@@ -47,7 +47,7 @@ def _get_glm_contrast_result(tmin=60, tmax=400):
     contrast_matrix = np.eye(design_matrix.shape[1])
     basic_conts = dict([(column, contrast_matrix[i])
                         for i, column in enumerate(design_matrix.columns)])
-    contrast_LvR = basic_conts['t_1'] - basic_conts['t_2']
+    contrast_LvR = basic_conts['t_1_0'] - basic_conts['t_2_0']
 
     return glm_est.compute_contrast(contrast_LvR)
 
@@ -128,7 +128,7 @@ def test_glm_scatter():
 
     assert isinstance(_get_glm_result().scatter(), Axes)
     assert isinstance(_get_glm_contrast_result().scatter(), Axes)
-    _get_glm_result(tmax=2974, tmin=0).surface_projection(condition="t_3",
+    _get_glm_result(tmax=2974, tmin=0).surface_projection(condition="t_3_0",
                                                           view="dorsal")
 
 

--- a/mne_nirs/statistics/tests/test_glm_type.py
+++ b/mne_nirs/statistics/tests/test_glm_type.py
@@ -47,7 +47,7 @@ def _get_glm_contrast_result(tmin=60, tmax=400):
     contrast_matrix = np.eye(design_matrix.shape[1])
     basic_conts = dict([(column, contrast_matrix[i])
                         for i, column in enumerate(design_matrix.columns)])
-    contrast_LvR = basic_conts['1.0'] - basic_conts['2.0']
+    contrast_LvR = basic_conts['t_1'] - basic_conts['t_2']
 
     return glm_est.compute_contrast(contrast_LvR)
 
@@ -128,7 +128,7 @@ def test_glm_scatter():
 
     assert isinstance(_get_glm_result().scatter(), Axes)
     assert isinstance(_get_glm_contrast_result().scatter(), Axes)
-    _get_glm_result(tmax=2974, tmin=0).surface_projection(condition="3.0",
+    _get_glm_result(tmax=2974, tmin=0).surface_projection(condition="t_3",
                                                           view="dorsal")
 
 


### PR DESCRIPTION
#### Whats the problem?

Nilearn recently changed the requirements for design matrix column names in https://github.com/nilearn/nilearn/pull/3025 which disallowed strings containing only numbers and strings with `/` as column names. 

Getting rid of the numbers is no problem, I prefer meaningful annotation names anyway.

However, I think its common in MNE to use names like `tapping/left` or `response/right`. See https://mne.tools/dev/auto_tutorials/epochs/40_autogenerate_metadata.html?highlight=hed#keeping-only-the-first-events-of-a-group

But nilearn now requires that the column names pass the following test:

```python
'response/right'.isidentifier()
# False

'response_right'.isidentifier()
# True
```

See lines: https://github.com/nilearn/nilearn/blob/ab9c68e502c4b92695cd658f5839a8207fd5e07e/nilearn/glm/first_level/hemodynamic_models.py#L428-L436

#### Whats the fix?

This PR checks that our design matrix column names are compatible with nilearn, and if they are not then prepends a `t_` to force them to be valid.

#### The problem

This PR also changes `/` to `_` in each design matrix column name, but this is not then harmonious with the rest of MNE. Further, it means that in some places of my script I use `tapping/left` and other places I will need to use `tapping_left`. This solution doesn't seem great, what is a better alternative?