### PR TITLE
Update MNE-NIRS for MNE-Python v0.24

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,9 +1,3 @@
-.. project-template documentation master file, created by
-   sphinx-quickstart on Mon Jan 18 14:44:12 2016.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-
 MNE-NIRS
 ========
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,9 +36,8 @@ Installation
 ------------
 
 MNE-NIRS requires you install Python and MNE-Python before installing MNE-NIRS.
-To install Python and MNE-Python follow `these instructions <https://mne.tools/dev/install/mne_python.html>`_.
-Some NIRS functionality is only available in the latest version of MNE-Python,
-so I suggest installing the latest development version `as described here <https://mne.tools/dev/install/advanced.html#other-python-distributions>`_.
+To install Python and MNE-Python follow `these instructions <https://mne.tools/stable/install/install_python.html>`_.
+You must use MNE-Python v0.24 or above.
 
 
 Run the following code to install MNE-NIRS:
@@ -48,7 +47,7 @@ Run the following code to install MNE-NIRS:
     >>> pip install mne-nirs
 
 
-Or if you wish to run the latest development version of MNE-NIRS (which I strongly suggest):
+Or if you wish to run the latest development version of MNE-NIRS:
 
 .. code:: bash
 
@@ -80,8 +79,7 @@ so this approach is best used for quickly exploring the capabilities of MNE-NIRS
 Alternatively, if you wish to run code locally on your own computer with your own data, you can run a 
 `docker instance locally <https://docs.docker.com/get-docker/>`_
 using the 
-`MNE-NIRS-docker <https://github.com/rob-luke/mne-nirs-docker>`_ image.
-See the web page for detailed instructions.
+`MNE-NIRS docker image <https://github.com/mne-tools/mne-nirs/pkgs/container/mne-nirs>`_ image.
 Using docker provides a notebook server running on your own computer, 
 it comes pre-prepared with MNE-Python, MNE-NIRS, and other useful packages installed.
 This approach gets you up and running with a single command, and provides
@@ -93,7 +91,7 @@ Upgrading your software version
 See the
 `MNE-Python instructions for how to update <https://mne.tools/dev/install/updating.html>`_
 the MNE-Python version.
-Similarly, you can update MNE-NIRS by running ``pip install -U --no-deps https://github.com/mne-tools/mne-nirs/archive/main.zip``
+Similarly, you can update MNE-NIRS to the latest development version by running ``pip install -U --no-deps https://github.com/mne-tools/mne-nirs/archive/main.zip``
 
 
 Acknowledgements

--- a/environment.yml
+++ b/environment.yml
@@ -37,6 +37,6 @@ dependencies:
 - pytables
 - pooch
 - nilearn
+- mne>=0.24
 - pip:
   - ipyvtklink
-  - https://github.com/mne-tools/mne-python/archive/main.zip

--- a/examples/general/plot_01_data_io.py
+++ b/examples/general/plot_01_data_io.py
@@ -201,7 +201,7 @@ sfreq = 10.  # in Hz
 # see :ref:`tut-info-class`, and for additional details on how continuous data
 # is stored in MNE-Python see :ref:`tut-raw-class`.
 # For a more extensive description of how to create MNE-Python data structures
-# from raw array data see :ref:`tut_creating_data_structures`.
+# from raw array data see :ref:`mne:tut_creating_data_structures`.
 
 info = mne.create_info(ch_names=ch_names, ch_types=ch_types, sfreq=sfreq)
 raw = mne.io.RawArray(data, info, verbose=True)
@@ -220,8 +220,8 @@ raw = mne.io.RawArray(data, info, verbose=True)
 # (montages) from some vendors, and this is demonstrated below.
 # Some handy tutorials for understanding sensor locations, coordinate systems,
 # and how to store and view this information in MNE-Python are:
-# :ref:`tut-sensor-locations`, :ref:`plot_source_alignment`, and
-# :ref:`ex-eeg-on-scalp`.
+# :ref:`mne:tut-sensor-locations`, :ref:`mne:plot_source_alignment`, and
+# :ref:`mne:ex-eeg-on-scalp`.
 #
 # Below is an example of how to load the optode positions for an Artinis
 # OctaMon device.

--- a/mne_nirs/tests/test_examples.py
+++ b/mne_nirs/tests/test_examples.py
@@ -29,13 +29,22 @@ def run_script_and_check(test_file_path):
 
 
 @pytest.mark.examples
-@pytest.mark.parametrize('fname', (["plot_10_hrf_simulation.py",
+@pytest.mark.parametrize('fname', (["plot_01_data_io.py",
+                                    "plot_05_datasets.py",
+                                    "plot_10_hrf_simulation.py",
                                     "plot_11_hrf_measured.py",
                                     "plot_12_group_glm.py",
+                                    "plot_13_fir_glm.py",
+                                    "plot_14_glm_components.py",
+                                    "plot_15_waveform.py",
                                     "plot_16_waveform_group.py",
                                     "plot_19_snirf.py",
                                     "plot_20_enhance.py",
+                                    "plot_21_artifacts.py",
+                                    "plot_22_quality.py",
                                     "plot_30_frequency.py",
+                                    "plot_40_mayer.py",
+                                    "plot_80_save_read_glm.py",
                                     "plot_99_bad.py"]))
 def test_examples(fname):
     test_file_path = examples_path() + fname

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ ipyvtklink
 pooch
 
 # mne-nirs specific requirements
-https://github.com/mne-tools/mne-python/archive/main.zip
+mne>=0.24
 lxml
 patsy
 tables

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -33,6 +33,5 @@ else
 	pip install --progress-bar off --pre imageio-ffmpeg xlrd mffpy
 fi
 
-pip install --progress-bar off --upgrade https://github.com/mne-tools/mne-python/archive/main.zip
 pip install --progress-bar off -r requirements.txt
 pip install --progress-bar off --upgrade -r requirements_testing.txt


### PR DESCRIPTION
Now that v0.24 is released we do not need to use the development version for MNE-NIRS. This PR updates the instructions and necessary CI, and requirements. Also some general clean up.