### PR TITLE
ENH: Speed up CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
             name: Set BASH_ENV
             command: |
               set -e
+              python3 -m venv ~/python_env --upgrade-deps
               echo "set -e" >> $BASH_ENV
               echo "export DISPLAY=:99" >> $BASH_ENV
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
@@ -26,6 +27,9 @@ jobs:
               echo "export MNE_3D_OPTION_ANTIALIAS=false" >> $BASH_ENV
               echo "export MNE_3D_BACKEND=pyvista" >> $BASH_ENV
               echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
+              echo "source ~/python_env/bin/activate" >> $BASH_ENV
+              mkdir -p ~/.local/bin
+              ln -s ~/python_env/bin/python ~/.local/bin/python
               echo "BASH_ENV:"
               cat $BASH_ENV
               mkdir -p ~/mne_data

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,10 +69,10 @@ jobs:
         - run:
             name: Get Python running
             command: |
-              python -m pip install --user --upgrade --progress-bar off pip setuptools
-              python -m pip install --user --upgrade --progress-bar off --pre sphinx
-              python -m pip install --user --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
-              python -m pip install --user -e .
+              python -m pip install --upgrade --progress-bar off pip setuptools
+              python -m pip install --upgrade --progress-bar off --pre sphinx
+              python -m pip install --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
+              python -m pip install -e .
 
 
         # Hack in uninstalls of libraries as necessary if pip doesn't do the right thing in upgrading for us...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ _xvfb: &xvfb
 
 jobs:
     build_docs:
-      docker:
-        - image: circleci/python:3.8.5-buster
+      machine:
+        image: ubuntu-2004:202111-01
       steps:
         - checkout
         - run:
@@ -23,6 +23,7 @@ jobs:
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
               echo "export XDG_RUNTIME_DIR=/tmp/runtime-circleci" >> $BASH_ENV
               source tools/get_minimal_commands.sh
+              echo "export MNE_3D_OPTION_ANTIALIAS=false" >> $BASH_ENV
               echo "export MNE_3D_BACKEND=pyvista" >> $BASH_ENV
               echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
               echo "BASH_ENV:"
@@ -103,7 +104,7 @@ jobs:
                python -c "import mne; mne.set_config('MNE_USE_CUDA', 'false')"  # this is needed for the config tutorial
                python -c "import mne; mne.set_config('MNE_LOGGING_LEVEL', 'info')"
                python -c "import mne; level = mne.get_config('MNE_LOGGING_LEVEL'); assert level.lower() == 'info', repr(level)"
-               
+
         - run:
             name: list packages
             command: |

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -300,7 +300,8 @@ sphinx_gallery_conf = {
             '../requirements.txt',
             '../requirements_doc.txt',
         ],
-    }
+    },
+    'plot_gallery': 'True',  # Avoid annoying str/bool default warning
 }
 
 

--- a/examples/general/plot_01_data_io.py
+++ b/examples/general/plot_01_data_io.py
@@ -6,11 +6,11 @@ r"""
 Importing Data From fNIRS Devices
 =================================
 
-.. note:: This tutorial is a mirror of the 
+.. note:: This tutorial is a mirror of the
           (`MNE tutorial <https://mne.tools/dev/auto_tutorials/io/30_reading_fnirs_data.html>`__),
           and is reproduced in MNE-NIRS for convenience and so that all
           relevant material is easily accessible to users.
-          
+
 fNIRS devices consist of two kinds of optodes: light sources (AKA "emitters" or
 "transmitters") and light detectors (AKA "receivers"). Channels are defined as
 source-detector pairs, and channel locations are defined as the midpoint
@@ -201,7 +201,7 @@ sfreq = 10.  # in Hz
 # see :ref:`tut-info-class`, and for additional details on how continuous data
 # is stored in MNE-Python see :ref:`tut-raw-class`.
 # For a more extensive description of how to create MNE-Python data structures
-# from raw array data see :ref:`mne:tut_creating_data_structures`.
+# from raw array data see :ref:`mne:tut-creating-data-structures`.
 
 info = mne.create_info(ch_names=ch_names, ch_types=ch_types, sfreq=sfreq)
 raw = mne.io.RawArray(data, info, verbose=True)
@@ -220,7 +220,7 @@ raw = mne.io.RawArray(data, info, verbose=True)
 # (montages) from some vendors, and this is demonstrated below.
 # Some handy tutorials for understanding sensor locations, coordinate systems,
 # and how to store and view this information in MNE-Python are:
-# :ref:`mne:tut-sensor-locations`, :ref:`mne:plot_source_alignment`, and
+# :ref:`mne:tut-sensor-locations`, :ref:`mne:tut-source-alignment`, and
 # :ref:`mne:ex-eeg-on-scalp`.
 #
 # Below is an example of how to load the optode positions for an Artinis

--- a/mne_nirs/statistics/_glm_level_first.py
+++ b/mne_nirs/statistics/_glm_level_first.py
@@ -4,13 +4,16 @@
 
 from copy import deepcopy
 from pathlib import PosixPath
+import warnings
 
 import pandas as pd
 import numpy as np
 from numpy import array_equal, where
 
-import nilearn.glm
-from nilearn.glm.first_level import run_glm as nilearn_glm
+with warnings.catch_warnings(record=True):
+    warnings.simplefilter('ignore')
+    import nilearn.glm
+    from nilearn.glm.first_level import run_glm as nilearn_glm
 
 from mne.channels.channels import ContainsMixin
 from mne.utils import fill_doc, warn, verbose, check_fname, _validate_type

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -3,7 +3,7 @@ sphinx
 https://github.com/numpy/numpydoc/archive/main.zip
 pydata-sphinx-theme>=0.6.3
 https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip
-sphinxcontrib-bibtex>=2.1.2
+sphinxcontrib-bibtex>=2.3
 memory_profiler
 neo
 seaborn

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -8,7 +8,9 @@ sudo apt install libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 \
 	libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
 	libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 \
 	graphviz optipng
-sudo ln -s /usr/lib/x86_64-linux-gnu/libxcb-util.so.0 /usr/lib/x86_64-linux-gnu/libxcb-util.so.1
+if [ ! -f /usr/lib/x86_64-linux-gnu/libxcb-util.so.1 ]; then
+	sudo ln -s /usr/lib/x86_64-linux-gnu/libxcb-util.so.0 /usr/lib/x86_64-linux-gnu/libxcb-util.so.1
+fi
 
 echo "Installing setuptools and sphinx"
 python -m pip install --progress-bar off --upgrade "pip!=20.3.0" setuptools wheel


### PR DESCRIPTION
1. Fix the `numpydoc` build error about plot_gallery being a str
2. Speed up CircleCI by using a machine image
3. Get rid of a warning (hopefully) that we see at the start of the doc build