### PR TITLE
Add custom channel weighting functionality in GLM region of interest

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -22,6 +22,12 @@ Enhancements
 
 * Add ability to provide custom channel weighting in :meth:`mne_nirs.statistics.RegressionResults.to_dataframe_region_of_interest` computation. By `Robert Luke`_.
 
+
+Fixes
+
+* Fix bug when using no weighting in :meth:`mne_nirs.statistics.RegressionResults.to_dataframe_region_of_interest`. By `Robert Luke`_.
+
+
 v0.1.2
 ------
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,8 +18,9 @@ To install a specific version of the library you would run ``pip install mne-nir
 v0.1.3 development
 ------------------
 
-* No change yet
+Enhancements
 
+* Add ability to provide custom channel weighting in :meth:`mne_nirs.statistics.RegressionResults.to_dataframe_region_of_interest` computation. By `Robert Luke`_.
 
 v0.1.2
 ------

--- a/examples/general/plot_70_visualise_brain.py
+++ b/examples/general/plot_70_visualise_brain.py
@@ -170,8 +170,8 @@ mne.viz.set_3d_view(fig, azimuth=140, elevation=95)
 
 
 # %%
-# Apply anatomically informed weighting to region of interest analysis
-# --------------------------------------------------------------------
+# Anatomically informed weighting in region of interest analysis
+# --------------------------------------------------------------
 #
 # As observed above, some channels have greater specificity to the desired
 # brain region than other channels.

--- a/examples/general/plot_70_visualise_brain.py
+++ b/examples/general/plot_70_visualise_brain.py
@@ -170,6 +170,41 @@ mne.viz.set_3d_view(fig, azimuth=140, elevation=95)
 
 
 # %%
+# Apply anatomically informed weighting to region of interest analysis
+# --------------------------------------------------------------------
+#
+# As observed above, some channels have greater specificity to the desired
+# brain region (in this case left inferior gyrus) than other channels.
+# Thus, when doing a region of interest analysis you may wish to give extra
+# weight to channels with greater sensitivity to the desired ROI.
+# This can be done by manually specifying the weights used in the region of
+# interest function call.
+# The details of the GLM analysis will not be described here, instead view the
+# # :ref:`fNIRS GLM tutorial <tut-fnirs-hrf>`. Instead, comments are provided
+# for the weighted region of interest function call.
+
+# Typical
+raw_od = optical_density(raw)
+raw_haemo = beer_lambert_law(raw_od)
+raw_haemo.resample(0.3)
+design_matrix = make_first_level_design_matrix(raw_haemo, stim_dur=5.0)
+glm_est = run_glm(raw_haemo, design_matrix)
+
+# First we create a dictionary for each region of interest.
+# Here we just have a single region of interest that contains all the channels.
+rois = dict()
+rois["All_LIFG_weighted"] = range(len(glm_est.ch_names))
+
+# Next we create a dictionary to store the weights for each channel in the ROI.
+# The weights will be the specificity to the left inferior gyrus.
+# The keys and length of each dictionary entry must match the ROI dictionary.
+weights = dict()
+weights["All_LIFG_weighted"] = specificity
+
+glm_est.to_dataframe_region_of_interest(rois, "Audio", weighted=weights)
+
+
+# %%
 # Preprocess fNIRS data
 # ---------------------
 #

--- a/examples/general/plot_70_visualise_brain.py
+++ b/examples/general/plot_70_visualise_brain.py
@@ -186,7 +186,7 @@ mne.viz.set_3d_view(fig, azimuth=140, elevation=95)
 # Typical
 raw_od = optical_density(raw)
 raw_haemo = beer_lambert_law(raw_od)
-raw_haemo.resample(0.6).pick("hbo")  # Speed increase for web server
+raw_haemo.resample(0.3).pick("hbo")  # Speed increase for web server
 sht_chans = get_short_channels(raw_haemo)
 raw_haemo = get_long_channels(raw_haemo)
 design_matrix = make_first_level_design_matrix(raw_haemo, stim_dur=13.0)
@@ -198,13 +198,11 @@ glm_est = run_glm(raw_haemo, design_matrix)
 rois = dict()
 rois["Audio_weighted"] = range(len(glm_est.ch_names))
 rois["Visual_weighted"] = range(len(glm_est.ch_names))
-rois["LIFG_weighted"] = range(len(glm_est.ch_names))
 
 # Next we compute the specificity for each channel to the auditory cortex
 # and also to the visual cortex.
 spec_aud = fold_landmark_specificity(raw_haemo, '42 - Primary and Auditory Association Cortex', fold_files, atlas="Brodmann")
 spec_vis = fold_landmark_specificity(raw_haemo, '17 - Primary Visual Cortex (V1)', fold_files, atlas="Brodmann")
-spec_ifg = fold_landmark_specificity(raw_haemo, 'L IFG (p. Triangularis)', fold_files, atlas="Juelich")
 
 # Next we create a dictionary to store the weights for each channel in the ROI.
 # The weights will be the specificity to the left inferior gyrus.
@@ -212,11 +210,16 @@ spec_ifg = fold_landmark_specificity(raw_haemo, 'L IFG (p. Triangularis)', fold_
 weights = dict()
 weights["Audio_weighted"] = spec_aud
 weights["Visual_weighted"] = spec_vis
-weights["LIFG_weighted"] = spec_ifg
 
+# Finally we compute region of interest results using the weights specified above
 out = glm_est.to_dataframe_region_of_interest(rois, ["Video", "Control"], weighted=weights)
 out["Significant"] = out["p"] < 0.05
 out
+
+
+# %%
+# In the table above we observe that the response to the visual condition
+# is only present in the visual region of interest.
 
 
 # %%

--- a/examples/general/plot_70_visualise_brain.py
+++ b/examples/general/plot_70_visualise_brain.py
@@ -174,16 +174,16 @@ mne.viz.set_3d_view(fig, azimuth=140, elevation=95)
 # --------------------------------------------------------------------
 #
 # As observed above, some channels have greater specificity to the desired
-# brain region (in this case left inferior gyrus) than other channels.
+# brain region than other channels.
 # Thus, when doing a region of interest analysis you may wish to give extra
 # weight to channels with greater sensitivity to the desired ROI.
 # This can be done by manually specifying the weights used in the region of
 # interest function call.
 # The details of the GLM analysis will not be described here, instead view the
-# # :ref:`fNIRS GLM tutorial <tut-fnirs-hrf>`. Instead, comments are provided
+# :ref:`fNIRS GLM tutorial <tut-fnirs-hrf>`. Instead, comments are provided
 # for the weighted region of interest function call.
 
-# Typical
+# Basic pipeline, simplified for example
 raw_od = optical_density(raw)
 raw_haemo = beer_lambert_law(raw_od)
 raw_haemo.resample(0.3).pick("hbo")  # Speed increase for web server
@@ -194,18 +194,18 @@ design_matrix["ShortHbO"] = np.mean(sht_chans.copy().pick(picks="hbo").get_data(
 glm_est = run_glm(raw_haemo, design_matrix)
 
 # First we create a dictionary for each region of interest.
-# Here we just have a single region of interest that contains all the channels.
+# Here we include all channels in each ROI, as we will later be applying
+# weights based on their specificity to the brain regions of interest.
 rois = dict()
 rois["Audio_weighted"] = range(len(glm_est.ch_names))
 rois["Visual_weighted"] = range(len(glm_est.ch_names))
 
-# Next we compute the specificity for each channel to the auditory cortex
-# and also to the visual cortex.
+# Next we compute the specificity for each channel to the auditory and visual cortex.
 spec_aud = fold_landmark_specificity(raw_haemo, '42 - Primary and Auditory Association Cortex', fold_files, atlas="Brodmann")
 spec_vis = fold_landmark_specificity(raw_haemo, '17 - Primary Visual Cortex (V1)', fold_files, atlas="Brodmann")
 
 # Next we create a dictionary to store the weights for each channel in the ROI.
-# The weights will be the specificity to the left inferior gyrus.
+# The weights will be the specificity to the ROI.
 # The keys and length of each dictionary entry must match the ROI dictionary.
 weights = dict()
 weights["Audio_weighted"] = spec_aud
@@ -219,7 +219,9 @@ out
 
 # %%
 # In the table above we observe that the response to the visual condition
-# is only present in the visual region of interest.
+# is only present in the visual region of interest. You can use this
+# technique to load any custom weighting, including weights exported from
+# other software.
 
 
 # %%

--- a/mne_nirs/statistics/_glm_level_first.py
+++ b/mne_nirs/statistics/_glm_level_first.py
@@ -126,6 +126,8 @@ class _BaseGLM(ContainsMixin):
             Dataframe containing GLM results.
         """
         from ..utils import glm_to_tidy
+        if order is None:
+            order = self.ch_names
         return glm_to_tidy(self.info, self._data, self.design, order=order)
 
     def scatter(self, conditions=[], exclude_no_interest=True, axes=None,

--- a/mne_nirs/statistics/_glm_level_first.py
+++ b/mne_nirs/statistics/_glm_level_first.py
@@ -387,7 +387,7 @@ class RegressionResults(_BaseGLM):
             can be provided.
             If a dictionary is provided, the keys and length of lists must
             match the ``group_by`` parameters.
-            The weights will be scaled internally to scale to 1.
+            The weights will be scaled internally to sum to 1.
         demographic_info : Bool
             Add an extra column with demographic information from
             info["subject_info"].
@@ -422,9 +422,9 @@ class RegressionResults(_BaseGLM):
         if weighted is True:
             tidy["Weighted"] = "Inverse standard error"
         elif weighted is False:
-            tidy["Weighted"] = "No channel weighting applied"
+            tidy["Weighted"] = "Equal"
         elif isinstance(weighted, dict):
-            tidy["Weighted"] = "Custom channel weighting applied"
+            tidy["Weighted"] = "Custom"
 
         if demographic_info:
             if 'age' in self.info['subject_info'].keys():

--- a/mne_nirs/statistics/_glm_level_first.py
+++ b/mne_nirs/statistics/_glm_level_first.py
@@ -417,6 +417,13 @@ class RegressionResults(_BaseGLM):
                                           cond_idx, cond, weighted)
             tidy = tidy.append(roi)
 
+        if weighted is True:
+            tidy["Weighted"] = "Inverse standard error"
+        elif weighted is False:
+            tidy["Weighted"] = "No channel weighting applied"
+        elif isinstance(weighted, dict):
+            tidy["Weighted"] = "Custom channel weighting applied"
+
         if demographic_info:
             if 'age' in self.info['subject_info'].keys():
                 tidy['Age'] = float(self.info["subject_info"]['age'])

--- a/mne_nirs/statistics/_roi.py
+++ b/mne_nirs/statistics/_roi.py
@@ -78,7 +78,7 @@ def _glm_region_of_interest(stats, group_by, cond_idx,
         can be provided.
         If a dictionary is provided, the keys and length of lists must
         match the ``group_by`` parameters.
-        The weights will be scaled internally to scale to 1.
+        The weights will be scaled internally to sum to 1.
 
     Returns
     -------

--- a/mne_nirs/statistics/_roi.py
+++ b/mne_nirs/statistics/_roi.py
@@ -121,7 +121,9 @@ def _glm_region_of_interest(stats, group_by, cond_idx,
             elif weighted is False:
                 weights = np.ones((len(ses), 1))
             elif isinstance(weighted, dict):
-                weights = [weights_region[ci] for ci in chroma_idxs]
+                weights = [float(weights_region[ci]) for ci in chroma_idxs]
+                weights = np.asarray(weights).reshape((len(ses), 1))
+            # Ensure weights sum to one
             weights /= np.sum(weights)
 
             theta = np.sum(thetas * weights)

--- a/mne_nirs/statistics/_roi.py
+++ b/mne_nirs/statistics/_roi.py
@@ -123,6 +123,8 @@ def _glm_region_of_interest(stats, group_by, cond_idx,
             elif isinstance(weighted, dict):
                 weights = [float(weights_region[ci]) for ci in chroma_idxs]
                 weights = np.asarray(weights).reshape((len(ses), 1))
+            else:
+                raise ValueError("Weighted parameter is not bool or dict")
             # Ensure weights sum to one
             weights /= np.sum(weights)
 

--- a/mne_nirs/statistics/_roi.py
+++ b/mne_nirs/statistics/_roi.py
@@ -119,7 +119,7 @@ def _glm_region_of_interest(stats, group_by, cond_idx,
             if weighted is True:
                 weights = 1. / np.asarray(ses)
             elif weighted is False:
-                weights = np.ones(len(ses))
+                weights = np.ones((len(ses), 1))
             elif isinstance(weighted, dict):
                 weights = [weights_region[ci] for ci in chroma_idxs]
             weights /= np.sum(weights)

--- a/mne_nirs/statistics/tests/test_glm_type.py
+++ b/mne_nirs/statistics/tests/test_glm_type.py
@@ -130,10 +130,10 @@ def test_glm_scatter():
     assert isinstance(_get_glm_contrast_result().scatter(), Axes)
 
 
-def test_glm_surface_projection():
-
-    _get_glm_result(tmax=2974, tmin=0).surface_projection(condition="3.0",
-                                                          view="dorsal")
+# def test_glm_surface_projection():
+#
+#     _get_glm_result(tmax=2974, tmin=0).surface_projection(condition="3.0",
+#                                                           view="dorsal")
 
 
 def test_results_glm_export_dataframe():
@@ -148,7 +148,6 @@ def test_results_glm_export_dataframe():
 
 def test_results_glm_export_dataframe_region_of_interest():
 
-    n_channels = 56
     res = _get_glm_result(tmax=400)
 
     # Create ROI with hbo only
@@ -205,6 +204,28 @@ def test_results_glm_export_dataframe_region_of_interest():
 
     # Multiple ROI, all conditions (default)
     df = res.to_dataframe_region_of_interest(rois, "1.0")
+
+    # With demographic information
+    df = res.to_dataframe_region_of_interest(rois, ["1.0", "3.0", "drift_1"],
+                                             demographic_info=True)
+    assert df.shape == (12, 9)
+    assert "Sex" in df.columns
+
+
+def test_results_glm_export_dataframe_region_of_interest_weighted():
+
+    res = _get_glm_result(tmax=400)
+
+    # Create ROI with hbo only
+    rois = dict()
+    rois["A"] = [0, 2, 4]
+    rois["B"] = [1, 3, 5]
+    rois["C"] = [6, 7, 8, 9]
+
+    df = res.to_dataframe_region_of_interest(rois, "1.0", weighted=False)
+    assert df.shape == (4, 8)
+    df = res.to_dataframe_region_of_interest(rois, "1.0", weighted=True)
+    assert df.shape == (4, 8)
 
 
 def test_create_results_glm_contrast():

--- a/mne_nirs/statistics/tests/test_glm_type.py
+++ b/mne_nirs/statistics/tests/test_glm_type.py
@@ -216,7 +216,7 @@ def test_results_glm_export_dataframe_region_of_interest_weighted():
 
     res = _get_glm_result(tmax=400)
 
-    # Create ROI with hbo only
+    # Create ROIs
     rois = dict()
     rois["A"] = [0, 2, 4]
     rois["B"] = [1, 3, 5]
@@ -226,6 +226,31 @@ def test_results_glm_export_dataframe_region_of_interest_weighted():
     assert df.shape == (4, 8)
     df = res.to_dataframe_region_of_interest(rois, "1.0", weighted=True)
     assert df.shape == (4, 8)
+
+    # Create weights
+    weights = dict()
+    weights["A"] = [0.1, 0.2, 0.4]
+    weights["B"] = [0.6, 0.1, 0.3]
+    weights["C"] = [16, 7, 8, 9]
+
+    df = res.to_dataframe_region_of_interest(rois, "1.0", weighted=weights)
+    assert df.shape == (4, 8)
+
+    with pytest.raises(ValueError, match='must be positive'):
+        weights["C"] = [16, 7, -8, 9]
+        _ = res.to_dataframe_region_of_interest(rois, "1.0",
+                                                weighted=weights)
+
+    with pytest.raises(ValueError, match='length of the keys'):
+        weights["C"] = [16, 7]
+        _ = res.to_dataframe_region_of_interest(rois, "1.0",
+                                                weighted=weights)
+
+    with pytest.raises(KeyError, match='Keys of group_by and weighted'):
+        bad_weights = dict()
+        bad_weights["Z"] = [0, 2, 4]
+        _ = res.to_dataframe_region_of_interest(rois, "1.0",
+                                                weighted=bad_weights)
 
 
 def test_create_results_glm_contrast():

--- a/mne_nirs/statistics/tests/test_glm_type.py
+++ b/mne_nirs/statistics/tests/test_glm_type.py
@@ -156,14 +156,14 @@ def test_results_glm_export_dataframe_region_of_interest():
 
     # Single ROI, single condition
     df = res.to_dataframe_region_of_interest(rois, "1.0")
-    assert df.shape == (1, 8)
+    assert df.shape == (1, 9)
     assert df.Condition[0] == "1.0"
     assert df.ROI[0] == "A"
     assert df.Chroma[0] == "hbo"
 
     # Single ROI, multiple conditions
     df = res.to_dataframe_region_of_interest(rois, ["1.0", "3.0", "drift_1"])
-    assert df.shape == (3, 8)
+    assert df.shape == (3, 9)
     assert (df.Condition == ["1.0", "3.0", "drift_1"]).all()
     assert (df.ROI == ["A", "A", "A"]).all()
 
@@ -175,7 +175,7 @@ def test_results_glm_export_dataframe_region_of_interest():
 
     # Multiple ROI, single condition
     df = res.to_dataframe_region_of_interest(rois, "1.0")
-    assert df.shape == (2, 8)
+    assert df.shape == (2, 9)
     assert df.Condition[0] == "1.0"
     assert df.Condition[1] == "1.0"
     assert df.ROI[0] == "A"
@@ -185,22 +185,22 @@ def test_results_glm_export_dataframe_region_of_interest():
 
     # Multiple ROI, multiple conditions
     df = res.to_dataframe_region_of_interest(rois, ["1.0", "3.0", "drift_1"])
-    assert df.shape == (6, 8)
+    assert df.shape == (6, 9)
 
     # Multiple ROI, all conditions (default)
     df = res.to_dataframe_region_of_interest(rois, "1.0")
-    assert df.shape == (2, 8)
+    assert df.shape == (2, 9)
 
     # HbO and HbR ROI
     rois["C"] = [6, 7, 8]
 
     # Multiple ROI, single condition
     df = res.to_dataframe_region_of_interest(rois, "1.0")
-    assert df.shape == (4, 8)
+    assert df.shape == (4, 9)
 
     # Multiple ROI, multiple conditions
     df = res.to_dataframe_region_of_interest(rois, ["1.0", "3.0", "drift_1"])
-    assert df.shape == (12, 8)
+    assert df.shape == (12, 9)
 
     # Multiple ROI, all conditions (default)
     df = res.to_dataframe_region_of_interest(rois, "1.0")
@@ -208,7 +208,7 @@ def test_results_glm_export_dataframe_region_of_interest():
     # With demographic information
     df = res.to_dataframe_region_of_interest(rois, ["1.0", "3.0", "drift_1"],
                                              demographic_info=True)
-    assert df.shape == (12, 9)
+    assert df.shape == (12, 10)
     assert "Sex" in df.columns
 
 
@@ -223,9 +223,11 @@ def test_results_glm_export_dataframe_region_of_interest_weighted():
     rois["C"] = [6, 7, 8, 9]
 
     df = res.to_dataframe_region_of_interest(rois, "1.0", weighted=False)
-    assert df.shape == (4, 8)
+    assert df.shape == (4, 9)
+    assert df.Weighted[0] == "No channel weighting applied"
     df = res.to_dataframe_region_of_interest(rois, "1.0", weighted=True)
-    assert df.shape == (4, 8)
+    assert df.shape == (4, 9)
+    assert df.Weighted[0] == "Inverse standard error"
 
     # Create weights
     weights = dict()
@@ -234,7 +236,8 @@ def test_results_glm_export_dataframe_region_of_interest_weighted():
     weights["C"] = [16, 7, 8, 9]
 
     df = res.to_dataframe_region_of_interest(rois, "1.0", weighted=weights)
-    assert df.shape == (4, 8)
+    assert df.shape == (4, 9)
+    assert df.Weighted[0] == "Custom channel weighting applied"
 
     with pytest.raises(ValueError, match='must be positive'):
         weights["C"] = [16, 7, -8, 9]

--- a/mne_nirs/statistics/tests/test_glm_type.py
+++ b/mne_nirs/statistics/tests/test_glm_type.py
@@ -228,11 +228,14 @@ def test_results_glm_export_dataframe_region_of_interest_weighted():
     assert df_uw.shape == (4, 9)
     assert df_uw.Weighted[0] == "No channel weighting applied"
     thetas = np.array(res_df.theta)
-    assert df_uw.query("ROI == 'A'").theta[0] == thetas[rois["A"]].mean()
+    # unweighted option should be the same as a simple mean
+    assert np.isclose(df_uw.query("ROI == 'A'").theta,
+                      thetas[rois["A"]].mean())
 
     df_w = res.to_dataframe_region_of_interest(rois, "1.0", weighted=True)
     assert df_w.shape == (4, 9)
     assert df_w.Weighted[0] == "Inverse standard error"
+    # weighted option should result in larger response
     assert df_uw.query("ROI == 'A'").theta[0] < \
            df_w.query("ROI == 'A'").theta[0]
 

--- a/mne_nirs/statistics/tests/test_glm_type.py
+++ b/mne_nirs/statistics/tests/test_glm_type.py
@@ -241,13 +241,17 @@ def test_results_glm_export_dataframe_region_of_interest_weighted():
 
     # Create weights
     weights = dict()
-    weights["A"] = [0.1, 0.2, 0.4, 0.4, 0.4, 0.4]
-    weights["B"] = [0.6, 0.1, 0.3, 0.4, 0.4, 0.4]
+    weights["A"] = [100000, 0.2, 0.4, 0.4, 0.4, 0.4]
+    weights["B"] = [0.6, 0.1, 0.3, 10000.4, 10000.4, 0.4]
     weights["C"] = [16, 7, 8, 9]
 
     df = res.to_dataframe_region_of_interest(rois, "1.0", weighted=weights)
     assert df.shape == (4, 9)
     assert df.Weighted[0] == "Custom channel weighting applied"
+    assert np.isclose(thetas[0], df.theta[0], atol=0.1e-6)
+    assert np.isclose((thetas[7] + thetas[9]) / 2, df.theta[1], atol=0.1e-6)
+    assert df.theta[2] > 0
+    assert df.theta[3] < 0
 
     with pytest.raises(ValueError, match='must be positive'):
         weights["C"] = [16, 7, -8, 9]

--- a/mne_nirs/statistics/tests/test_glm_type.py
+++ b/mne_nirs/statistics/tests/test_glm_type.py
@@ -128,6 +128,10 @@ def test_glm_scatter():
 
     assert isinstance(_get_glm_result().scatter(), Axes)
     assert isinstance(_get_glm_contrast_result().scatter(), Axes)
+
+
+def test_glm_surface_projection():
+
     _get_glm_result(tmax=2974, tmin=0).surface_projection(condition="3.0",
                                                           view="dorsal")
 
@@ -136,9 +140,71 @@ def test_results_glm_export_dataframe():
 
     n_channels = 56
     res = _get_glm_result(tmax=400)
+
     df = res.to_dataframe()
 
     assert df.shape == (6 * n_channels, 12)
+
+
+def test_results_glm_export_dataframe_region_of_interest():
+
+    n_channels = 56
+    res = _get_glm_result(tmax=400)
+
+    # Create ROI with hbo only
+    rois = dict()
+    rois["A"] = [0, 2, 4]
+
+    # Single ROI, single condition
+    df = res.to_dataframe_region_of_interest(rois, "1.0")
+    assert df.shape == (1, 8)
+    assert df.Condition[0] == "1.0"
+    assert df.ROI[0] == "A"
+    assert df.Chroma[0] == "hbo"
+
+    # Single ROI, multiple conditions
+    df = res.to_dataframe_region_of_interest(rois, ["1.0", "3.0", "drift_1"])
+    assert df.shape == (3, 8)
+    assert (df.Condition == ["1.0", "3.0", "drift_1"]).all()
+    assert (df.ROI == ["A", "A", "A"]).all()
+
+    # Single ROI, all conditions (default)
+    df = res.to_dataframe_region_of_interest(rois, "1.0")
+
+    # HbR only ROI
+    rois["B"] = [1, 3, 5]
+
+    # Multiple ROI, single condition
+    df = res.to_dataframe_region_of_interest(rois, "1.0")
+    assert df.shape == (2, 8)
+    assert df.Condition[0] == "1.0"
+    assert df.Condition[1] == "1.0"
+    assert df.ROI[0] == "A"
+    assert df.ROI[1] == "B"
+    assert df.Chroma[0] == "hbo"
+    assert df.Chroma[1] == "hbr"
+
+    # Multiple ROI, multiple conditions
+    df = res.to_dataframe_region_of_interest(rois, ["1.0", "3.0", "drift_1"])
+    assert df.shape == (6, 8)
+
+    # Multiple ROI, all conditions (default)
+    df = res.to_dataframe_region_of_interest(rois, "1.0")
+    assert df.shape == (2, 8)
+
+    # HbO and HbR ROI
+    rois["C"] = [6, 7, 8]
+
+    # Multiple ROI, single condition
+    df = res.to_dataframe_region_of_interest(rois, "1.0")
+    assert df.shape == (4, 8)
+
+    # Multiple ROI, multiple conditions
+    df = res.to_dataframe_region_of_interest(rois, ["1.0", "3.0", "drift_1"])
+    assert df.shape == (12, 8)
+
+    # Multiple ROI, all conditions (default)
+    df = res.to_dataframe_region_of_interest(rois, "1.0")
 
 
 def test_create_results_glm_contrast():

--- a/mne_nirs/statistics/tests/test_glm_type.py
+++ b/mne_nirs/statistics/tests/test_glm_type.py
@@ -226,7 +226,7 @@ def test_results_glm_export_dataframe_region_of_interest_weighted():
 
     df_uw = res.to_dataframe_region_of_interest(rois, "1.0", weighted=False)
     assert df_uw.shape == (4, 9)
-    assert df_uw.Weighted[0] == "No channel weighting applied"
+    assert df_uw.Weighted[0] == "Equal"
     thetas = np.array(res_df.theta)
     # unweighted option should be the same as a simple mean
     assert np.isclose(df_uw.query("ROI == 'A'").theta,
@@ -247,7 +247,7 @@ def test_results_glm_export_dataframe_region_of_interest_weighted():
 
     df = res.to_dataframe_region_of_interest(rois, "1.0", weighted=weights)
     assert df.shape == (4, 9)
-    assert df.Weighted[0] == "Custom channel weighting applied"
+    assert df.Weighted[0] == "Custom"
     assert np.isclose(thetas[0], df.theta[0], atol=0.1e-6)
     assert np.isclose((thetas[7] + thetas[9]) / 2, df.theta[1], atol=0.1e-6)
     assert df.theta[2] > 0

--- a/mne_nirs/statistics/tests/test_glm_type.py
+++ b/mne_nirs/statistics/tests/test_glm_type.py
@@ -130,10 +130,10 @@ def test_glm_scatter():
     assert isinstance(_get_glm_contrast_result().scatter(), Axes)
 
 
-# def test_glm_surface_projection():
-#
-#     _get_glm_result(tmax=2974, tmin=0).surface_projection(condition="3.0",
-#                                                           view="dorsal")
+def test_glm_surface_projection():
+
+    _get_glm_result(tmax=2974, tmin=0).surface_projection(condition="3.0",
+                                                          view="dorsal")
 
 
 def test_results_glm_export_dataframe():

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -7,7 +7,6 @@ from functools import partial
 import numpy as np
 import mne
 import mne_nirs
-import numpy as np
 
 from mne.utils._testing import requires_module
 from mne_nirs.experimental_design.tests.test_experimental_design import \

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -6,7 +6,6 @@ import pytest
 import mne
 import mne_nirs
 import numpy as np
-from mne.utils import (requires_pysurfer, traits_test)
 from mne_nirs.experimental_design.tests.test_experimental_design import \
     _load_dataset
 from mne_nirs.experimental_design import make_first_level_design_matrix
@@ -15,8 +14,6 @@ from mne_nirs.visualisation import plot_glm_topo, plot_glm_surface_projection
 from mne_nirs.utils import glm_to_tidy
 
 
-@requires_pysurfer
-@traits_test
 def test_plot_nirs_source_detector_pyvista():
     mne.viz.set_3d_backend('pyvista')
     data_path = mne.datasets.testing.data_path() + '/NIRx/nirscout'
@@ -144,8 +141,6 @@ def test_fig_from_axes():
         _get_fig_from_axes([1, 2, 3])
 
 
-@requires_pysurfer
-@traits_test
 @pytest.mark.filterwarnings('ignore:.*nilearn.glm module is experimental.*:')
 def test_run_plot_GLM_projection():
     mne.viz.set_3d_backend('pyvista')


### PR DESCRIPTION
#### Reference issue

Currently the region of interest calculation has two weighting options:
1. Weight each channel equally (`weighted=False`)
1. Weight each channel by the inverse of the standard error fo the GLM fit (`weighted=True`)

#### Problem / Use Case

Each fNIRS channel is located at a different position on the scalp and has different sensitivity to brain regions of interest. A user may wish to weight the channels in their region of interest according to the sensitivity to desired brain structure. I.e. weight channels with better sensitivity to brain structure higher than channels with low sensitivity.

#### What does this implement/fix?

Adds a third option when calculation region of interest results from individual channels

3. Custom channel weighting. Allows the user to manually specify the relative weighting of each channel in the ROI computation.

The user can specify a dictionary in the same format as the `group_by` parameter. The channels are then weighted according to the custom values. The values are normalised to one, so that the scaling is not altered (this was already implemented for the SE option).

#### Additional information
This is useful in conjunction with other software that provides channel by channel sensitivity to desired brain regions such as fOLD, AtlasViewer, etc

Also fixed a bug when `weighted=False` was used. This was not being normalised to one, so results were scaled. I never used this, so never noticed it before, just caught it when making the tests.


#### TODO

- [x] More tests
- [x] Example in docs