### PR TITLE
Potential fix for #423

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,16 +2,16 @@
 numpy>=1.15.4
 scipy>=1.1.0
 matplotlib
-pyqt5>=5.10,<5.14; platform_system == "Darwin"
-pyqt5>=5.10,!=5.15.2,!=5.15.3; platform_system == "Linux"
-pyqt5>=5.10,!=5.15.3; platform_system != "Linux" and platform_system != "Darwin"
+pyqt>=5.10,<5.14; platform_system == "Darwin"
+pyqt>=5.10,!=5.15.2,!=5.15.3; platform_system == "Linux"
+pyqt>=5.10,!=5.15.3; platform_system != "Linux" and platform_system != "Darwin"
 pyqt5-sip
 sip
 scikit-learn
 nibabel
 numba
 h5py
-pandas==1.3.2
+pandas>=1.3.2
 numexpr
 jupyter
 python-picard


### PR DESCRIPTION
Potential fix for this issue:

[Issue 423 here](https://github.com/mne-tools/mne-nirs/issues/423)

I have removed pandas version pinning, and changed the package name from pyqt5 (which doesn't exist on conda) to pyqt.



