### PR TITLE
Fix SNIRF data shapes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,10 @@ ARG mne_nirs_v
 
 USER root
 
+RUN pip install statsmodels lets-plot dabest fooof h5io
 RUN pip install https://github.com/nilearn/nilearn/archive/${nilearn_v}.zip
 RUN pip install https://codeload.github.com/rob-luke/mne-bids/zip/nirs
 RUN pip install https://github.com/mne-tools/mne-nirs/archive/${mne_nirs_v}.zip
-RUN pip install -r requirements.txt
-RUN pip install -r requirements_doc.txt
-RUN pip install -r requirements_testing.txt
 
 # Copy examples
 COPY ./ /home/mne_user/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,12 @@ ARG mne_nirs_v
 
 USER root
 
-RUN pip install statsmodels lets-plot dabest fooof
 RUN pip install https://github.com/nilearn/nilearn/archive/${nilearn_v}.zip
 RUN pip install https://codeload.github.com/rob-luke/mne-bids/zip/nirs
 RUN pip install https://github.com/mne-tools/mne-nirs/archive/${mne_nirs_v}.zip
+RUN pip install -r requirements.txt
+RUN pip install -r requirements_doc.txt
+RUN pip install -r requirements_testing.txt
 
 # Copy examples
 COPY ./ /home/mne_user/

--- a/environment.yml
+++ b/environment.yml
@@ -38,6 +38,7 @@ dependencies:
 - pytables
 - pooch
 - nilearn
-- mne>=0.24
 - ipyvtklink
 - mne-qt-browser
+- pip:
+  - https://github.com/mne-tools/mne-python/archive/main.zip

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
 - xlrd
 - scikit-learn
 - h5py
+- h5io
 - pillow
 - statsmodels
 - jupyter

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -12,7 +12,7 @@ from mne.io.pick import _picks_to_idx
 
 # The currently-implemented spec can be found here:
 # https://github.com/fNIRS/snirf/blob/52de9a6724ddd0c9dcd36d8d11007895fed74205/snirf_specification.md
-SPEC_FORMAT_VERSION = '1.0 - Draft 3'
+SPEC_FORMAT_VERSION = '1.0'
 
 
 def write_raw_snirf(raw, fname):
@@ -37,7 +37,7 @@ def write_raw_snirf(raw, fname):
     with h5py.File(fname, 'w') as f:
         nirs = f.create_group('/nirs')
         f.create_dataset('formatVersion',
-                         data=[_str_encode(SPEC_FORMAT_VERSION)])
+                         data=_str_encode(SPEC_FORMAT_VERSION))
 
         _add_metadata_tags(raw, nirs)
         _add_single_data_block(raw, nirs)
@@ -72,18 +72,18 @@ def _add_metadata_tags(raw, nirs):
     datestr = raw.info['meas_date'].strftime('%Y-%m-%d')
     timestr = raw.info['meas_date'].strftime('%H:%M:%SZ')
     metadata_tags.create_dataset('MeasurementDate',
-                                 data=[_str_encode(datestr)])
+                                 data=_str_encode(datestr))
     metadata_tags.create_dataset('MeasurementTime',
-                                 data=[_str_encode(timestr)])
+                                 data=_str_encode(timestr))
 
     # Store demographic info
     subject_id = raw.info['subject_info']['first_name']
-    metadata_tags.create_dataset('SubjectID', data=[_str_encode(subject_id)])
+    metadata_tags.create_dataset('SubjectID', data=_str_encode(subject_id))
 
     # Store the units of measurement
-    metadata_tags.create_dataset('LengthUnit', data=[_str_encode('m')])
-    metadata_tags.create_dataset('TimeUnit', data=[_str_encode('s')])
-    metadata_tags.create_dataset('FrequencyUnit', data=[_str_encode('Hz')])
+    metadata_tags.create_dataset('LengthUnit', data=_str_encode('m'))
+    metadata_tags.create_dataset('TimeUnit', data=_str_encode('s'))
+    metadata_tags.create_dataset('FrequencyUnit', data=_str_encode('Hz'))
 
     # Add non standard (but allowed) custom metadata tags
     if 'birthday' in raw.info['subject_info']:
@@ -147,13 +147,15 @@ def _add_measurement_lists(raw, data_block):
         source_idx = sources.index(_extract_source(ch_name)) + 1
         detector_idx = detectors.index(_extract_detector(ch_name)) + 1
         wavelength_idx = wavelengths.index(_extract_wavelength(ch_name)) + 1
-        ch_group.create_dataset('sourceIndex', data=[source_idx])
-        ch_group.create_dataset('detectorIndex', data=[detector_idx])
-        ch_group.create_dataset('wavelengthIndex', data=[wavelength_idx])
+        ch_group.create_dataset('sourceIndex', data=source_idx, dtype='int32')
+        ch_group.create_dataset('detectorIndex', data=detector_idx,
+                                dtype='int32')
+        ch_group.create_dataset('wavelengthIndex', data=wavelength_idx,
+                                dtype='int32')
 
         # Set dataType and dataTypeIndex for CW Amplitude measurements
-        ch_group.create_dataset('dataType', data=1)
-        ch_group.create_dataset('dataTypeIndex', data=1)
+        ch_group.create_dataset('dataType', data=1, dtype='int32')
+        ch_group.create_dataset('dataTypeIndex', data=1, dtype='int32')
 
 
 def _add_probe_info(raw, nirs):
@@ -243,7 +245,7 @@ def _add_stim_info(raw, nirs):
             stims[idx_t, :] = [raw.annotations.onset[trg], 5.0,
                                raw.annotations.duration[trg]]
         stim_group.create_dataset('data', data=stims)
-        stim_group.create_dataset('name', data=[_str_encode(desc)])
+        stim_group.create_dataset('name', data=_str_encode(desc))
 
 
 def _get_unique_source_list(raw):

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -39,6 +39,8 @@ def test_snirf_write(fname, tmpdir):
     raw = read_raw_snirf(test_file)
 
     valid, result = validateSnirf(str(test_file))
+    if not valid:
+        result.display()
     assert valid
 
     # Check annotations are the same
@@ -140,6 +142,6 @@ def _verify_snirf_required_fields(test_file):
 def _verify_snirf_version_str(test_file):
     """Verify that the version string contains the correct spec version."""
     with h5py.File(test_file, 'r') as h5:
-        version_str = h5['/formatVersion'][0].decode('UTF-8')
+        version_str = h5['/formatVersion'][()].decode('UTF-8')
         expected_str = SPEC_FORMAT_VERSION
         assert version_str == expected_str

--- a/mne_nirs/statistics/_glm_level_first.py
+++ b/mne_nirs/statistics/_glm_level_first.py
@@ -9,6 +9,7 @@ import warnings
 import pandas as pd
 import numpy as np
 from numpy import array_equal, where
+from h5io import read_hdf5, write_hdf5
 
 with warnings.catch_warnings(record=True):
     warnings.simplefilter('ignore')
@@ -19,7 +20,6 @@ from mne.channels.channels import ContainsMixin
 from mne.utils import fill_doc, warn, verbose, check_fname, _validate_type
 from mne.io.pick import _picks_to_idx
 from mne.io.constants import FIFF
-from mne.externals.h5io import read_hdf5, write_hdf5
 from mne import Info
 
 from ..visualisation._plot_GLM_topo import _plot_glm_topo,\

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -3,10 +3,12 @@
 # License: BSD (3-clause)
 
 import pytest
+from functools import partial
+import numpy as np
 import mne
 import mne_nirs
-import numpy as np
-from mne.utils import (requires_pysurfer, traits_test)
+
+from mne.utils._testing import requires_module
 from mne_nirs.experimental_design.tests.test_experimental_design import \
     _load_dataset
 from mne_nirs.experimental_design import make_first_level_design_matrix
@@ -15,8 +17,11 @@ from mne_nirs.visualisation import plot_glm_topo, plot_glm_surface_projection
 from mne_nirs.utils import glm_to_tidy
 
 
-@requires_pysurfer
-@traits_test
+def requires_pyvista():
+    return partial(requires_module, name='pyvista')
+
+
+@requires_pyvista()
 def test_plot_nirs_source_detector_pyvista():
     mne.viz.set_3d_backend('pyvista')
     data_path = mne.datasets.testing.data_path() + '/NIRx/nirscout'
@@ -144,8 +149,7 @@ def test_fig_from_axes():
         _get_fig_from_axes([1, 2, 3])
 
 
-@requires_pysurfer
-@traits_test
+@requires_pyvista()
 @pytest.mark.filterwarnings('ignore:.*nilearn.glm module is experimental.*:')
 def test_run_plot_GLM_projection():
     mne.viz.set_3d_backend('pyvista')

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ ipyvtklink
 pooch
 
 # mne-nirs specific requirements
-mne>=0.24
+https://github.com/mne-tools/mne-python/archive/main.zip
 h5io
 lxml
 patsy

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ pooch
 
 # mne-nirs specific requirements
 mne>=0.24
+h5io
 lxml
 patsy
 tables

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -26,3 +26,6 @@ sphinx-fontawesome
 seaborn
 fooof
 pysnirf2>=0.3.1
+statsmodels
+lets-plot
+dabest

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -25,7 +25,7 @@ Ipython
 sphinx-fontawesome
 seaborn
 fooof
-pysnirf2>=0.3.1
+pysnirf2>=0.4.2
 statsmodels
 lets-plot
 dabest


### PR DESCRIPTION
#### Reference issue
Version 0.4.2 of https://github.com/BUNPC/pysnirf2 enforces that integers are not stored as single length arrays, these changes ensure that MNE files comply with the SNIRF validator.


#### What does this implement/fix?
1. Stores integers as numerics rather than single length arrays
2. Enforces 32 bit integers rather that 64
3. Use dependency rather than `mne.externals` (see https://github.com/mne-tools/mne-python/pull/10199)
4. Bump SNIRF version to 1.0 as we are compliant with the validator
5. Switch to MNE main branch as it handles SNIRF file reading better


#### Additional information
FYI @sstucker and thanks for the great validator
Also see https://github.com/fNIRS/snirf/issues/98
