### PR TITLE
Use specific nilearn version for building all docs

### DIFF
--- a/.github/workflows/SphinxBuild.yml
+++ b/.github/workflows/SphinxBuild.yml
@@ -58,6 +58,11 @@ jobs:
         run: ./tools/github_actions_install.sh
         name: 'Install MNE'
       - shell: bash -el {0}
+        run: |
+          pip uninstall nilearn
+          pip install nilearn==0.8.1
+        name: 'Install nilearn that works with older MNE-NIRS versions'
+      - shell: bash -el {0}
         run: ./tools/github_actions_infos.sh
         name: 'Show infos'
       - shell: bash -el {0}


### PR DESCRIPTION
#### Reference issue
In #433 the version of nilearn used in the CI was updated to be the main branch and examples and code were changed to work with breaking changes in nilearn 0.9. However, old versions of MNE-NIRS do not work with this nilearn 0.9. 

The doc system for MNE-NIRS builds the docs for all versions of the software when a change is made to main. However, all versions are built with the same dependencies. So, due to the change in #433 all previous versions of MNE-NIRS documentation are not building.

The reason all versions of the docs are built each time is so that the banners pointing you to the latest version are updated and so is the version dropdowns etc.

#### What does this implement/fix?
This PR changes the version of nilearn that the docs are built with to be the last release version. All versions of MNE-NIRS should work with nilearn 0.8.1


#### Additional information
This is not a sustainable change. I see a few options moving forward

1. Find a way to build the docs for each previous mne-nirs release with the dependencies at the time (I cant see how this could be possible).
2. Only build the latest version of the docs (this will break banners and dropdowns)
3. Remove docs for versions of MNE-NIRS older than the current dev
4. ????

Thoughts @larsoner ?
