### PR TITLE
Just build single html docs version

### DIFF
--- a/tools/github_actions_docs.sh
+++ b/tools/github_actions_docs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -ef
 
 cd doc
-make html
+make html-single


### PR DESCRIPTION
Currently the doc building system is broken. 
See #436 for more details

This should at least build the latest docs until we can rebuild and link all the previous versions.