### PR TITLE
ENH: plot_3d_montage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+test-output.xml
+junit-results.xml
 *,cover
 .hypothesis/
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -230,6 +230,7 @@ fNIRS specific data visualisation.
 .. autosummary::
    :toctree: generated/
 
+   plot_3d_montage
    plot_nirs_source_detector
 
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -27,6 +27,7 @@ Enhancements
 
 * Update SNIRF exporter to meet v1.0 validator requirements :meth:`mne_nirs.io.snirf.write_raw_snirf`. By `Robert Luke`_.
 * Add ability to provide custom channel weighting in :meth:`mne_nirs.statistics.RegressionResults.to_dataframe_region_of_interest` computation. By `Robert Luke`_.
+* Add function to plot montages on 3D brain with source, detector, and channel naming :func:`mne_nirs.visualisation.plot_3d_montage`. By `Eric Larson`_.
 
 
 Fixes

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -232,8 +232,8 @@ intersphinx_mapping = {
     'scipy': ('https://scipy.github.io/devdocs', None),
     'matplotlib': ('https://matplotlib.org/', None),
     'mne': ('https://mne.tools/stable', None),
-    'nilearn': ('http://nilearn.github.io/', None),
-    'sklearn': ('http://scikit-learn.org/stable', None),
+    'nilearn': ('https://nilearn.github.io/', None),
+    'sklearn': ('https://scikit-learn.org/stable', None),
     'mne_bids': ('https://mne.tools/mne-bids/stable', None),
     'statsmodels': ('https://www.statsmodels.org/stable', None)
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -228,8 +228,8 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/{.major}'.format(
         sys.version_info), None),
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
+    'numpy': ('https://numpy.org/devdocs', None),
+    'scipy': ('https://scipy.github.io/devdocs', None),
     'matplotlib': ('https://matplotlib.org/', None),
     'mne': ('https://mne.tools/stable', None),
     'nilearn': ('http://nilearn.github.io/', None),

--- a/examples/general/plot_70_visualise_brain.py
+++ b/examples/general/plot_70_visualise_brain.py
@@ -95,6 +95,8 @@ brain.add_sensors(raw.info, trans='fsaverage', fnirs=['channels', 'pairs', 'sour
 brain.show_view(azimuth=180, elevation=80, distance=450)
 
 # %%
+# .. _tut-fnirs-vis-brain-plot-3d-montage:
+#
 # Plot sensor channel numbers
 # ---------------------------
 # Often for publications and sanity checking, it's convenient to create an

--- a/examples/general/plot_70_visualise_brain.py
+++ b/examples/general/plot_70_visualise_brain.py
@@ -94,6 +94,23 @@ brain = mne.viz.Brain('fsaverage', subjects_dir=subjects_dir, background='w', co
 brain.add_sensors(raw.info, trans='fsaverage', fnirs=['channels', 'pairs', 'sources', 'detectors'])
 brain.show_view(azimuth=180, elevation=80, distance=450)
 
+# %%
+# Plot sensor channel numbers
+# ---------------------------
+# Often for publications and sanity checking, it's convenient to create an
+# image showing the channel numbers along with the (typically) 10-20 location
+# in the correct locations in a 3D view. The function
+# :func:`mne_nirs.visualization.plot_3d_montage` gives us this once we
+# specify which views to use to show each channel pair:
+
+view_map = {
+    'left-lat': np.r_[np.arange(1, 27), 28],
+    'caudal': np.r_[27, np.arange(43, 53)],
+    'right-lat': np.r_[np.arange(29, 43), 44],
+}
+
+fig = mne_nirs.visualisation.plot_3d_montage(
+    raw.info, view_map=view_map, subjects_dir=subjects_dir)
 
 # %%
 # Plot sensor channels and anatomical region of interest

--- a/examples/general/plot_70_visualise_brain.py
+++ b/examples/general/plot_70_visualise_brain.py
@@ -100,7 +100,7 @@ brain.show_view(azimuth=180, elevation=80, distance=450)
 # Often for publications and sanity checking, it's convenient to create an
 # image showing the channel numbers along with the (typically) 10-20 location
 # in the correct locations in a 3D view. The function
-# :func:`mne_nirs.visualization.plot_3d_montage` gives us this once we
+# :func:`mne_nirs.visualisation.plot_3d_montage` gives us this once we
 # specify which views to use to show each channel pair:
 
 view_map = {

--- a/examples/general/plot_70_visualise_brain.py
+++ b/examples/general/plot_70_visualise_brain.py
@@ -109,7 +109,7 @@ view_map = {
     'right-lat': np.r_[np.arange(29, 43), 44],
 }
 
-fig = mne_nirs.visualisation.plot_3d_montage(
+fig_montage = mne_nirs.visualisation.plot_3d_montage(
     raw.info, view_map=view_map, subjects_dir=subjects_dir)
 
 # %%

--- a/mne_nirs/__init__.py
+++ b/mne_nirs/__init__.py
@@ -10,5 +10,6 @@ from . import simulation
 from . import statistics
 from . import utils
 from . import visualisation
+from . import visualisation as viz  # for MNE-Python users
 
 __all__ = ['__version__']

--- a/mne_nirs/conftest.py
+++ b/mne_nirs/conftest.py
@@ -6,6 +6,8 @@
 import warnings
 
 import pytest
+import mne
+from mne.datasets import testing
 
 
 # most of this adapted from MNE-Python
@@ -77,3 +79,15 @@ def close_all():
     import matplotlib.pyplot as plt
     yield
     plt.close('all')
+
+
+@pytest.fixture
+@testing.requires_testing_data
+def requires_pyvista():
+    pyvista = pytest.importorskip('pyvista')
+    try:
+        mne.viz.set_3d_backend('pyvista')
+    except Exception as exc:
+        pytest.skip(f'Requires pyvista, got: {exc}')
+    yield
+    pyvista.close_all()

--- a/mne_nirs/conftest.py
+++ b/mne_nirs/conftest.py
@@ -85,9 +85,7 @@ def close_all():
 @testing.requires_testing_data
 def requires_pyvista():
     pyvista = pytest.importorskip('pyvista')
-    try:
-        mne.viz.set_3d_backend('pyvista')
-    except Exception as exc:
-        pytest.skip(f'Requires pyvista, got: {exc}')
+    pytest.importorskip('pyvistaqt')
+    mne.viz.set_3d_backend('pyvista')
     yield
     pyvista.close_all()

--- a/mne_nirs/statistics/tests/test_glm_type.py
+++ b/mne_nirs/statistics/tests/test_glm_type.py
@@ -11,11 +11,15 @@ import matplotlib
 from matplotlib.pyplot import Axes
 
 import mne
+from mne.datasets import testing
 import nilearn
 
 from mne_nirs.statistics import RegressionResults, read_glm
 from mne_nirs.experimental_design import make_first_level_design_matrix
 from mne_nirs.statistics import run_glm
+
+data_path = testing.data_path(download=False)
+subjects_dir = data_path + '/subjects'
 
 
 def _get_minimal_haemo_data(tmin=0, tmax=60):
@@ -133,10 +137,11 @@ def test_glm_scatter():
     assert isinstance(_get_glm_contrast_result().scatter(), Axes)
 
 
-def test_glm_surface_projection():
+def test_glm_surface_projection(requires_pyvista):
 
     res = _get_glm_result(tmax=2974, tmin=0)
-    res.surface_projection(condition="e3p0", view="dorsal")
+    res.surface_projection(condition="e3p0", view="dorsal", surface="white",
+                           subjects_dir=subjects_dir)
     with pytest.raises(KeyError, match='not found in conditions'):
         res.surface_projection(condition='foo')
 

--- a/mne_nirs/visualisation/__init__.py
+++ b/mne_nirs/visualisation/__init__.py
@@ -7,3 +7,4 @@ from._plot_GLM_topo import (plot_glm_topo, plot_glm_contrast_topo,
                             plot_glm_group_topo)
 from ._plot_quality_metrics import plot_timechannel_quality_metric
 from ._plot_GLM_surface_projection import plot_glm_surface_projection
+from ._plot_3d_montage import plot_3d_montage

--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -116,7 +116,7 @@ def plot_3d_montage(info, view_map, *, src_det_names='auto',
     brain = Brain(
         subject, 'both', 'pial', views=['lat'] * len(views),
         size=size, background='w', units='m',
-        view_layout='horizontal')
+        view_layout='horizontal', subjects_dir=subjects_dir)
     with _safe_brain_close(brain):
         brain.add_head(dense=False, alpha=0.1)
         brain.add_sensors(

--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -154,7 +154,7 @@ def plot_3d_montage(info, view_map, *, src_det_names='auto',
                     vp.SetWorldPoint(np.r_[ch_pos, 1.])
                     vp.WorldToDisplay()
                     ch_pos = (np.array(vp.GetDisplayPoint()[:2]) -
-                            np.array(vp.GetOrigin()))
+                              np.array(vp.GetOrigin()))
 
                     actor = brain.plotter.add_text(
                         name, ch_pos, font_size=font_size, color=(0., 0., 0.),

--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -175,7 +175,4 @@ def _safe_brain_close(brain):
     try:
         yield
     finally:
-        try:
-            brain.close()
-        except Exception:
-            pass
+        brain.close()

--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -56,8 +56,8 @@ def plot_3d_montage(info, *, view_map, src_det_names='auto',
         _check_option('src_det_names', src_det_names, ('auto',),
                       extra='when str')
         # Decide if we can map to 10-20 locations
-        names, pos = zip(*
-            transform_to_head(make_standard_montage('standard_1020'))
+        names, pos = zip(
+            *transform_to_head(make_standard_montage('standard_1020'))
             .get_positions()['ch_pos'].items())
         pos = np.array(pos, float)
         locs = dict()

--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -1,0 +1,149 @@
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD (3-clause)
+
+import numpy as np
+
+from mne import pick_info, pick_types
+from mne.channels import make_standard_montage
+from mne.channels.montage import transform_to_head
+from mne.fixes import _get_args
+from mne.io import Info
+from mne.transforms import _get_trans, apply_trans
+from mne.utils import _validate_type, _check_option
+from mne.viz import Brain
+
+
+def plot_3d_montage(info, *, view_map, src_det_names='auto',
+                    subject='fsaverage', trans='fsaverage',
+                    subjects_dir=None):
+    """
+    Plot a 3D sensor montage.
+
+    Parameters
+    ----------
+    info : instance of Info
+        Measurement info.
+    view_map : dict
+        Dict of view (key) to channel-pair-numbers (value) to use when
+        plotting. Note that, because these get plotted as 1-based channel
+        *numbers*, the values should be 1-based rather than 0-based.
+    src_det_names : None | dict | str
+        Source and detector names to use. "auto" (default) will see if the
+        channel locations correspond to standard 10-20 locations and will
+        use those if they do (otherwise will act like None). None will use
+        S1, S2, ..., D1, D2, ..., etc. Can also be an explicit dict mapping.
+    subject : str
+        The subject.
+    trans : str | Transfrom
+        The subjects head<->MRI transform.
+    subjects_dir : str
+        The subjects directory.
+
+    Returns
+    -------
+    figure : matplotlib.figure.Figure
+        The matplotlib figimage.
+    """
+    import matplotlib.pyplot as plt
+    from scipy.spatial.distance import cdist
+    _validate_type(info, Info, 'info')
+    _validate_type(view_map, dict, 'views')
+    _validate_type(src_det_names, (None, dict, str), 'src_det_names')
+    info = pick_info(info, pick_types(info, fnirs=True, exclude=())[::2])
+    info['bads'] = []
+    if isinstance(src_det_names, str):
+        _check_option('src_det_names', src_det_names, ('auto',),
+                      extra='when str')
+        # Decide if we can map to 10-20 locations
+        names, pos = zip(*
+            transform_to_head(make_standard_montage('standard_1020'))
+            .get_positions()['ch_pos'].items())
+        pos = np.array(pos, float)
+        locs = dict()
+        bad = False
+        for ch in info['chs']:
+            name = ch['ch_name']
+            s_name, d_name = name.split()[0].split('_')
+            for name, loc in [(s_name, ch['loc'][3:6]),
+                              (d_name, ch['loc'][6:9])]:
+                if name in locs:
+                    continue
+                # see if it's close enough
+                idx = np.where(cdist(loc[np.newaxis], pos)[0] < 1e-3)[0]
+                if len(idx) < 1:
+                    bad = True
+                    break
+                # Some are duplicated (e.g., T7+T3) but we can rely on the
+                # first one being the canonical one
+                locs[name] = names[idx[0]]
+            if bad:
+                break
+        src_det_names = None if bad else locs
+
+    trans = _get_trans('fsaverage', 'head', 'mri')[0]
+    views = list()
+    for key, num in view_map.items():
+        _validate_type(key, str, f'view_map key {repr(key)}')
+        _validate_type(num, np.ndarray, f'view_map[{repr(key)}]')
+        if '-' in key:
+            hemi, v = key.split('-', maxsplit=1)
+            hemi = dict(left='lh', right='rh')[hemi]
+            views.append((hemi, v, num))
+        else:
+            views.append(('lh', key, num))
+    del view_map
+    size = (400 * len(views), 400)
+    brain = Brain(
+        subject, 'both', 'pial', views=['lat'] * len(views),
+        size=size, background='w', units='m',
+        view_layout='horizontal')
+    brain.add_head(dense=False, alpha=0.1)
+    brain.add_sensors(
+        info, trans='fsaverage',
+        fnirs=['channels', 'pairs', 'sources', 'detectors'])
+    add_text_kwargs = dict()
+    if 'render' in _get_args(brain.plotter.add_text):
+        add_text_kwargs['render'] = False
+    for col, view in enumerate(views):
+        plotted = set()
+        brain.show_view(
+            view[1], hemi=view[0], focalpoint=(0, -0.02, 0.02),
+            distance=0.4, row=0, col=col)
+        brain.plotter.subplot(0, col)
+        vp = brain.plotter.renderer
+        for ci in view[2]:  # figure out what we need to plot
+            ch_name = str(ci)
+            this_ch = info['chs'][ci - 1]
+            name = this_ch['ch_name']
+            s_name, d_name = name.split()[0].split('_')
+            if src_det_names is not None:
+                s_name = src_det_names[s_name]
+                d_name = src_det_names[d_name]
+            needed = [
+                (ch_name, this_ch['loc'][:3], 12, 'Centered'),
+                (s_name, this_ch['loc'][3:6], 8, 'Bottom'),
+                (d_name, this_ch['loc'][6:9], 8, 'Bottom'),
+            ]
+            for name, ch_pos, font_size, va in needed:
+                if name in plotted:
+                    continue
+                plotted.add(name)
+                # name = rev_dict[use_]  # XXX ADD THIS
+                ch_pos = apply_trans(trans, ch_pos)
+                vp.SetWorldPoint(np.r_[ch_pos, 1.])
+                vp.WorldToDisplay()
+                ch_pos = (np.array(vp.GetDisplayPoint()[:2]) -
+                          np.array(vp.GetOrigin()))
+
+                actor = brain.plotter.add_text(
+                    name, ch_pos, font_size=font_size, color=(0., 0., 0.),
+                    **add_text_kwargs)
+                prop = actor.GetTextProperty()
+                getattr(prop, f'SetVerticalJustificationTo{va}')()
+                prop.SetJustificationToCentered()
+                actor.SetTextProperty(prop)
+                prop.SetBold(True)
+    img = brain.screenshot()
+    brain.close()
+    return plt.figimage(img, resize=True).figure

--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -102,7 +102,7 @@ def plot_3d_montage(info, view_map, *, src_det_names='auto',
             logger.info('Source-detector names automatically mapped to 10-20 '
                         'locations')
 
-    head_mri_n = _get_trans(trans, 'head', 'mri')[0]
+    head_mri_t = _get_trans(trans, 'head', 'mri')[0]
     del trans
     views = list()
     for key, num in view_map.items():

--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -38,12 +38,16 @@ def plot_3d_montage(info, view_map, *, src_det_names='auto',
         ``'{view}'``
             For views like ``'caudal'`` that are along the midline.
 
-        See :meth:`mne.viz.Brain.show_view` for ``view`` options.
+        See :meth:`mne.viz.Brain.show_view` for ``view`` options, and the
+        Examples section below for usage examples.
     src_det_names : None | dict | str
         Source and detector names to use. "auto" (default) will see if the
         channel locations correspond to standard 10-20 locations and will
         use those if they do (otherwise will act like None). None will use
-        S1, S2, ..., D1, D2, ..., etc. Can also be an explicit dict mapping.
+        S1, S2, ..., D1, D2, ..., etc. Can also be an explicit dict mapping,
+        for example::
+
+            src_det_names=dict(S1='Fz', D1='FCz', ...)
     subject : str
         The subject.
     trans : str | Transform
@@ -58,6 +62,21 @@ def plot_3d_montage(info, view_map, *, src_det_names='auto',
     -------
     figure : matplotlib.figure.Figure
         The matplotlib figimage.
+
+    Examples
+    --------
+    For a Hitachi system with two sets of 12 source-detector arrangements,
+    one on each side of the head, showing 1-12 on the left and 13-24 on the
+    right can be accomplished using the following ``view_map``::
+
+        >>> view_map = {
+        ...     'left-lat': np.arange(1, 13),
+        ...     'right-lat': np.arange(13, 25),
+        ... }
+
+    NIRx typically involves more complicated arrangements. See
+    :ref:`the 3D tutorial <tut-fnirs-vis-brain-plot-3d-montage>` for
+    an advanced example that incorporates the ``'caudal'`` view as well.
     """
     import matplotlib.pyplot as plt
     from scipy.spatial.distance import cdist

--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -10,13 +10,14 @@ from mne.channels.montage import transform_to_head
 from mne.fixes import _get_args
 from mne.io import Info
 from mne.transforms import _get_trans, apply_trans
-from mne.utils import _validate_type, _check_option
+from mne.utils import _validate_type, _check_option, verbose, logger
 from mne.viz import Brain
 
 
-def plot_3d_montage(info, *, view_map, src_det_names='auto',
+@verbose
+def plot_3d_montage(info, view_map, *, src_det_names='auto',
                     subject='fsaverage', trans='fsaverage',
-                    subjects_dir=None):
+                    subjects_dir=None, verbose=None):
     """
     Plot a 3D sensor montage.
 
@@ -48,6 +49,7 @@ def plot_3d_montage(info, *, view_map, src_det_names='auto',
         The subjects head<->MRI transform.
     subjects_dir : str
         The subjects directory.
+    %(verbose)s
 
     Returns
     -------
@@ -88,7 +90,14 @@ def plot_3d_montage(info, *, view_map, src_det_names='auto',
                 locs[name] = names[idx[0]]
             if bad:
                 break
-        src_det_names = None if bad else locs
+        if bad:
+            src_det_names = None
+            logger.info('Could not automatically map source/detector names to '
+                        '10-20 locations.')
+        else:
+            src_det_names = locs
+            logger.info('Source-detector names automatically mapped to 10-20 '
+                        'locations')
 
     trans = _get_trans('fsaverage', 'head', 'mri')[0]
     views = list()

--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -35,7 +35,7 @@ def plot_3d_montage(info, *, view_map, src_det_names='auto',
         S1, S2, ..., D1, D2, ..., etc. Can also be an explicit dict mapping.
     subject : str
         The subject.
-    trans : str | Transfrom
+    trans : str | Transform
         The subjects head<->MRI transform.
     subjects_dir : str
         The subjects directory.

--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -28,6 +28,15 @@ def plot_3d_montage(info, *, view_map, src_det_names='auto',
         Dict of view (key) to channel-pair-numbers (value) to use when
         plotting. Note that, because these get plotted as 1-based channel
         *numbers*, the values should be 1-based rather than 0-based.
+        The keys are of the form:
+
+        ``'{side}-{view}'``
+            For views like ``'left-lat'`` or ``'right-frontal'`` where the side
+            matters.
+        ``'{view}'``
+            For views like ``'caudal'`` that are along the midline.
+
+        See :meth:`mne.viz.Brain.show_view` for ``view`` options.
     src_det_names : None | dict | str
         Source and detector names to use. "auto" (default) will see if the
         channel locations correspond to standard 10-20 locations and will

--- a/mne_nirs/visualisation/_plot_GLM_surface_projection.py
+++ b/mne_nirs/visualisation/_plot_GLM_surface_projection.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from mne import stc_near_sensors, EvokedArray, read_source_spaces, Info
 from mne.datasets import sample
 from mne.io.constants import FIFF
-from mne import verbose
+from mne.utils import verbose, get_subjects_dir
 
 
 @verbose
@@ -120,7 +120,7 @@ def _plot_3d_evoked_array(inst, ea, picks="hbo",
         ea = ea.pick(picks=picks)
 
     if subjects_dir is None:
-        subjects_dir = sample.data_path() + '/subjects'
+        subjects_dir = get_subjects_dir(raise_error=True)
     if src is None:
         fname_src_fs = os.path.join(subjects_dir, 'fsaverage', 'bem',
                                     'fsaverage-ico-5-src.fif')

--- a/mne_nirs/visualisation/_plot_GLM_surface_projection.py
+++ b/mne_nirs/visualisation/_plot_GLM_surface_projection.py
@@ -7,7 +7,6 @@ import numpy as np
 from copy import deepcopy
 
 from mne import stc_near_sensors, EvokedArray, read_source_spaces, Info
-from mne.datasets import sample
 from mne.io.constants import FIFF
 from mne.utils import verbose, get_subjects_dir
 

--- a/mne_nirs/visualisation/_plot_GLM_surface_projection.py
+++ b/mne_nirs/visualisation/_plot_GLM_surface_projection.py
@@ -134,7 +134,7 @@ def _plot_3d_evoked_array(inst, ea, picks="hbo",
     # Generate source estimate
     kwargs = dict(
         evoked=ea, subject='fsaverage', trans='fsaverage',
-        distance=distance, mode=mode,
+        distance=distance, mode=mode, surface=surface,
         subjects_dir=subjects_dir, src=src, project=True)
     stc = stc_near_sensors(picks=picks, **kwargs, verbose=verbose)
 

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -3,12 +3,10 @@
 # License: BSD (3-clause)
 
 import pytest
-from functools import partial
 import numpy as np
 import mne
 import mne_nirs
 
-from mne.channels.montage import make_standard_montage
 from mne.datasets import testing
 from mne.utils import catch_logging
 

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -193,6 +193,9 @@ def test_run_plot_GLM_projection(requires_pyvista):
     (raw_path, True),
 ])
 def test_plot_3d_montage(requires_pyvista, fname_raw, to_1020):
+    import pyvista
+    pyvista.close_all()
+    assert len(pyvista.plotting._ALL_PLOTTERS) == 0
     raw = mne.io.read_raw_nirx(fname_raw)
     if to_1020:
         need = set(sum(
@@ -205,6 +208,7 @@ def test_plot_3d_montage(requires_pyvista, fname_raw, to_1020):
     with catch_logging() as log:
         mne_nirs.viz.plot_3d_montage(
             raw.info, view_map, subjects_dir=subjects_dir, verbose=True)
+    assert len(pyvista.plotting._ALL_PLOTTERS) == 0
     log = log.getvalue().lower()
     if to_1020:
         assert 'automatically mapped' in log

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -23,18 +23,6 @@ raw_path = testing_path + '/NIRx/nirscout/nirx_15_2_recording_w_short'
 subjects_dir = testing_path + '/subjects'
 
 
-@pytest.fixture
-@testing.requires_testing_data
-def requires_pyvista():
-    pyvista = pytest.importorskip('pyvista')
-    try:
-        mne.viz.set_3d_backend('pyvista')
-    except Exception as exc:
-        pytest.skip(f'Requires pyvista, got: {exc}')
-    yield
-    pyvista.close_all()
-
-
 def test_plot_nirs_source_detector_pyvista(requires_pyvista):
     raw = mne.io.read_raw_nirx(raw_path)
 

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -182,7 +182,7 @@ def test_run_plot_GLM_projection(requires_pyvista):
     brain = plot_glm_surface_projection(raw_haemo.copy().pick("hbo"),
                                         df, clim='auto', view='dorsal',
                                         colorbar=True, size=(800, 700),
-                                        value="theta",
+                                        value="theta", surface='white',
                                         subjects_dir=subjects_dir)
     assert type(brain) == mne.viz._brain.Brain
 
@@ -204,9 +204,12 @@ def test_plot_3d_montage(requires_pyvista, fname_raw, to_1020):
         mon.rename_channels({h: n for h, n in zip(mon.ch_names, need)})
         raw.set_montage(mon)
     view_map = {'left-lat': np.arange(1, len(raw.ch_names) // 2 + 1)}
+    # We use "sample" here even though it's wrong so that we can have a head
+    # surface
     with catch_logging() as log:
         mne_nirs.viz.plot_3d_montage(
-            raw.info, view_map, subjects_dir=subjects_dir, verbose=True)
+            raw.info, view_map, subject='sample', surface='white',
+            subjects_dir=subjects_dir, verbose=True)
     assert len(pyvista.plotting._ALL_PLOTTERS) == 0
     log = log.getvalue().lower()
     if to_1020:

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -191,7 +191,7 @@ def test_plot_3d_montage(requires_pyvista, fname_raw, to_1020):
         mon = mne.channels.make_standard_montage('standard_1020')
         mon.rename_channels({h: n for h, n in zip(mon.ch_names, need)})
         raw.set_montage(mon)
-    n_labels = len(raw.ch_names) // 2 + 1
+    n_labels = len(raw.ch_names) // 2
     view_map = {'left-lat': np.arange(1, n_labels // 2),
                 'caudal': np.arange(n_labels // 2, n_labels + 1)}
     # We use "sample" here even though it's wrong so that we can have a head

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -182,7 +182,8 @@ def test_run_plot_GLM_projection(requires_pyvista):
     brain = plot_glm_surface_projection(raw_haemo.copy().pick("hbo"),
                                         df, clim='auto', view='dorsal',
                                         colorbar=True, size=(800, 700),
-                                        value="theta")
+                                        value="theta",
+                                        subjects_dir=subjects_dir)
     assert type(brain) == mne.viz._brain.Brain
 
 

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -191,7 +191,9 @@ def test_plot_3d_montage(requires_pyvista, fname_raw, to_1020):
         mon = mne.channels.make_standard_montage('standard_1020')
         mon.rename_channels({h: n for h, n in zip(mon.ch_names, need)})
         raw.set_montage(mon)
-    view_map = {'left-lat': np.arange(1, len(raw.ch_names) // 2 + 1)}
+    n_labels = len(raw.ch_names) // 2 + 1
+    view_map = {'left-lat': np.arange(1, n_labels // 2),
+                'caudal': np.arange(n_labels // 2, n_labels + 1)}
     # We use "sample" here even though it's wrong so that we can have a head
     # surface
     with catch_logging() as log:


### PR DESCRIPTION
Closes #440

Code is getting there. If MNE-Python's montage functions are used, autodetection works:
```
    view_map = {
        'left-lat': np.arange(1, 13),
        'right-lat': np.arange(13, 25),
    }
    fig = mne_nirs.visualisation.plot_3d_montage(
        use['h'].info, view_map=view_map, subjects_dir=subjects_dir)
```
![montage](https://user-images.githubusercontent.com/2365790/152600237-69e592c6-2b61-4580-b448-41f76427fb20.png)

NIRx doesn't use the same positions as the builtin MNE-Python montage, so we need to do more for this case:
```
    view_map = {
        'left-lat': np.r_[np.arange(1, 13),
                          np.arange(58, 74),
                          np.arange(75, 78)],
        'caudal': np.r_[42,
                        np.arange(45, 58),
                        74,
                        np.arange(78, 85)],
        'right-lat': np.r_[np.arange(13, 42), 43, 44],
    }
    fig = mne_nirs.visualisation.plot_3d_montage(
        info, view_map=view_map, subjects_dir=subjects_dir)
```

![montage](https://user-images.githubusercontent.com/2365790/152600345-b3d697d7-ef64-4b37-a4e6-c914a5c2f2ca.png)

The [modified example](https://2145-254026779-gh.circle-artifacts.com/0/dev/auto_examples/general/plot_70_visualise_brain.html#plot-sensor-channel-numbers) has the same problem:
```
view_map = {
    'left-lat': np.r_[np.arange(1, 27), 28],
    'caudal': np.r_[27, np.arange(43, 53)],
    'right-lat': np.r_[np.arange(29, 43), 44],
}

fig = mne_nirs.visualisation.plot_3d_montage(
    raw.info, view_map=view_map, subjects_dir=subjects_dir)
```
![Screenshot from 2022-02-04 15-40-10](https://user-images.githubusercontent.com/2365790/152600391-3d09d276-b9d3-4fc1-8370-95f987ec2f67.png)


# Todo

- [ ] ~~Fix NIRx 10-20 detection~~
- [x] Actually describe the `view_map` option (hemi-brainview keys)
- [x] Add tests

## Option 1

@rob-luke one option would be to make a function for NIRx that converts their 10-20 positions to MNE-Python's. Do they have standard 10-20 positions that then populate `info`? If so, we could come up with a lookup table, then people can do:
```
mne_nirs.something.convert_nirx_1020(raw.info, copy=False)
```
to update their channel positions. Users can even avoid making it permanent just by doing in their code before plotting:
```
plot_info = mne_nirs.something.convert_nirx_1020(raw.info)  # default is copy=True
mne_nirs.visualisation.plot_3d_montage(plot_info, ...)
```

## Option 2

Another clean way to go would be, instead of `'auto'`, the default value could be `src_det_names='standard_1020'` to give a montage to load. Then in MNE-Python we can add a `'nirx'` named montage, so then the call here would be `src_det_names='nirx'` or so. Or we just make `nirx_montage = mne_nirs.something.get_montage('nirx')` that you can then pass directly as `src_det_names=nirx_montage` to tell it which positions to look at to get the names.

I think my vote is for Option 2, because it nicely generalizes. You could imagine generalizing to `get_montage('flow')` or so. And then `src_det_names=<str>` could by convenience call the mne_nirs get_montage first, and if it doesn't exist, try loading the MNE-Python get_montage (like standard_1020)... and we could maybe even make `auto` detect the acq system and triage to the correct one (standard_1020 for Hitachi, nirx for nirx, flow for kernel flow, etc.).