### PR TITLE
ENH: Allow setting ch_names

### DIFF
--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -49,7 +49,7 @@ def plot_3d_montage(info, view_map, *, src_det_names='auto',
         for example::
 
             src_det_names=dict(S1='Fz', D1='FCz', ...)
-    ch_names : str | dict
+    ch_names : str | dict | None
         If ``'numbered'`` (default), use ``['1', '2', ...]`` for the channel
         names, or ``None`` to use ``['S1_D2', 'S2_D1', ...]``. Can also be a
         dict to provide a mapping from the ``'S1_D2'``-style names (keys) to
@@ -92,11 +92,12 @@ def plot_3d_montage(info, view_map, *, src_det_names='auto',
     _validate_type(info, Info, 'info')
     _validate_type(view_map, dict, 'views')
     _validate_type(src_det_names, (None, dict, str), 'src_det_names')
-    _validate_type(ch_names, (dict, str), 'ch_names')
+    _validate_type(ch_names, (dict, str, None), 'ch_names')
     info = pick_info(info, pick_types(info, fnirs=True, exclude=())[::2])
     if isinstance(ch_names, str):
         _check_option('ch_names', ch_names, ('numbered',), extra='when str')
-        ch_names = {name: ni for ni, name in enumerate(info['ch_names'], 1)}
+        ch_names = {
+            name.split()[0]: ni for ni, name in enumerate(info['ch_names'], 1)}
     info['bads'] = []
     if isinstance(src_det_names, str):
         _check_option('src_det_names', src_det_names, ('auto',),

--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -165,23 +165,20 @@ def plot_3d_montage(info, view_map, *, src_det_names='auto', ch_names=None,
             vp = brain.plotter.renderer
             for ci in view[2]:  # figure out what we need to plot
                 ch_name = str(ci)
-                if ch_names is not None:
-                    ch_name = ch_names[ch_name]
                 this_ch = info['chs'][ci - 1]
                 name = this_ch['ch_name']
                 s_name, d_name = name.split()[0].split('_')
-                if src_det_names is not None:
-                    s_name = src_det_names[s_name]
-                    d_name = src_det_names[d_name]
                 needed = [
-                    (ch_name, this_ch['loc'][:3], 12, 'Centered'),
-                    (s_name, this_ch['loc'][3:6], 8, 'Bottom'),
-                    (d_name, this_ch['loc'][6:9], 8, 'Bottom'),
+                    (ch_names, ch_name, this_ch['loc'][:3], 12, 'Centered'),
+                    (src_det_names, s_name, this_ch['loc'][3:6], 8, 'Bottom'),
+                    (src_det_names, d_name, this_ch['loc'][6:9], 8, 'Bottom'),
                 ]
-                for name, ch_pos, font_size, va in needed:
+                for lookup, name, ch_pos, font_size, va in needed:
                     if name in plotted:
                         continue
                     plotted.add(name)
+                    if lookup is not None:
+                        name = lookup[name]
                     ch_pos = apply_trans(head_mri_t, ch_pos)
                     vp.SetWorldPoint(np.r_[ch_pos, 1.])
                     vp.WorldToDisplay()

--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -16,7 +16,7 @@ from mne.viz import Brain
 
 
 @verbose
-def plot_3d_montage(info, view_map, *, src_det_names='auto',
+def plot_3d_montage(info, view_map, *, src_det_names='auto', ch_names=None,
                     subject='fsaverage', trans='fsaverage', surface='pial',
                     subjects_dir=None, verbose=None):
     """
@@ -48,6 +48,15 @@ def plot_3d_montage(info, view_map, *, src_det_names='auto',
         for example::
 
             src_det_names=dict(S1='Fz', D1='FCz', ...)
+    ch_names : dict | None
+        If None, use ``['1', '2', ...]`` for the channel names. Can be a
+        dict to provide a mapping from these to other names, e.g.,
+        ``defaultdict(lambda: '')`` will prevent showing the names, and
+        this will use names of the form ``S1_D2``::
+
+            dict(zip(str(ii), name.split()[0]) for ii, name in enumerate(raw.ch_names[::2], 1)))
+
+        .. versionadded:: 0.3
     subject : str
         The subject.
     trans : str | Transform
@@ -77,7 +86,7 @@ def plot_3d_montage(info, view_map, *, src_det_names='auto',
     NIRx typically involves more complicated arrangements. See
     :ref:`the 3D tutorial <tut-fnirs-vis-brain-plot-3d-montage>` for
     an advanced example that incorporates the ``'caudal'`` view as well.
-    """
+    """  # noqa: E501
     import matplotlib.pyplot as plt
     from scipy.spatial.distance import cdist
     _validate_type(info, Info, 'info')
@@ -156,6 +165,8 @@ def plot_3d_montage(info, view_map, *, src_det_names='auto',
             vp = brain.plotter.renderer
             for ci in view[2]:  # figure out what we need to plot
                 ch_name = str(ci)
+                if ch_names is not None:
+                    ch_name = ch_names[ch_name]
                 this_ch = info['chs'][ci - 1]
                 name = this_ch['ch_name']
                 s_name, d_name = name.split()[0].split('_')

--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -97,7 +97,8 @@ def plot_3d_montage(info, view_map, *, src_det_names='auto',
     if isinstance(ch_names, str):
         _check_option('ch_names', ch_names, ('numbered',), extra='when str')
         ch_names = {
-            name.split()[0]: ni for ni, name in enumerate(info['ch_names'], 1)}
+            name.split()[0]: str(ni)
+            for ni, name in enumerate(info['ch_names'], 1)}
     info['bads'] = []
     if isinstance(src_det_names, str):
         _check_option('src_det_names', src_det_names, ('auto',),
@@ -173,22 +174,26 @@ def plot_3d_montage(info, view_map, *, src_det_names='auto',
                 ch_name = this_ch['ch_name'].split()[0]
                 s_name, d_name = ch_name.split('_')
                 needed = [
-                    (ch_names, ch_name, this_ch['loc'][:3], 12, 'Centered'),
-                    (src_det_names, s_name, this_ch['loc'][3:6], 8, 'Bottom'),
-                    (src_det_names, d_name, this_ch['loc'][6:9], 8, 'Bottom'),
+                    (ch_names, 'ch_names', ch_name,
+                     this_ch['loc'][:3], 12, 'Centered'),
+                    (src_det_names, 'src_det_names', s_name,
+                     this_ch['loc'][3:6], 8, 'Bottom'),
+                    (src_det_names, 'src_det_names', d_name,
+                     this_ch['loc'][6:9], 8, 'Bottom'),
                 ]
-                for lookup, name, ch_pos, font_size, va in needed:
+                for lookup, lname, name, ch_pos, font_size, va in needed:
                     if name in plotted:
                         continue
                     plotted.add(name)
+                    orig_name = name
                     if lookup is not None:
                         name = lookup[name]
+                    _validate_type(name, str, f'{lname}[{repr(orig_name)}]')
                     ch_pos = apply_trans(head_mri_t, ch_pos)
                     vp.SetWorldPoint(np.r_[ch_pos, 1.])
                     vp.WorldToDisplay()
                     ch_pos = (np.array(vp.GetDisplayPoint()[:2]) -
                               np.array(vp.GetOrigin()))
-
                     actor = brain.plotter.add_text(
                         name, ch_pos, font_size=font_size, color=(0., 0., 0.),
                         **add_text_kwargs)

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -2,6 +2,8 @@
 #
 # License: BSD (3-clause)
 
+from collections import defaultdict
+
 import pytest
 import numpy as np
 import mne
@@ -181,11 +183,12 @@ def test_run_plot_GLM_projection(requires_pyvista):
 
 
 @requires_mne_1
-@pytest.mark.parametrize('fname_raw, to_1020', [
-    (raw_path, False),
-    (raw_path, True),
+@pytest.mark.parametrize('fname_raw, to_1020, ch_names', [
+    (raw_path, False, None),
+    (raw_path, True, 'numbered'),
+    (raw_path, True, defaultdict(lambda: '')),
 ])
-def test_plot_3d_montage(requires_pyvista, fname_raw, to_1020):
+def test_plot_3d_montage(requires_pyvista, fname_raw, to_1020, ch_names):
     import pyvista
     pyvista.close_all()
     assert len(pyvista.plotting._ALL_PLOTTERS) == 0
@@ -205,7 +208,7 @@ def test_plot_3d_montage(requires_pyvista, fname_raw, to_1020):
     with catch_logging() as log:
         mne_nirs.viz.plot_3d_montage(
             raw.info, view_map, subject='sample', surface='white',
-            subjects_dir=subjects_dir, verbose=True)
+            subjects_dir=subjects_dir, ch_names=ch_names, verbose=True)
     assert len(pyvista.plotting._ALL_PLOTTERS) == 0
     log = log.getvalue().lower()
     if to_1020:


### PR DESCRIPTION
It's nice to be able to remap the `ch_names` that get plotted. I'm not convinced this is the best API. Maybe instead we should have:
```
ch_names : str | dict
    Channel names to plot. Can be ``'numeric'`` (default) to use ``['1', '2', ...]``,
    ``'short'`` to use ``info['ch_names'][::2]`` (e.g., ``['S1_D2', 'S2_D1', ...]``),
    or a dict to provide a mapping from ``info['ch_names'][::2]`` (keys) to the
    desired names.
```
@rob-luke WDYT?