### PR TITLE
MAINT: Update dataset hash

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -245,6 +245,12 @@ else:
     report_scraper = mne.report._ReportScraper()
     scrapers += (report_scraper,)
     del backend
+try:
+    import mne_qt_browser
+    if mne.viz.get_browser_backend() == 'qt':
+        scrapers += (mne.viz._scraper._PyQtGraphScraper(),)
+except ImportError:
+    pass
 
 # Resolve binder filepath_prefix. From the docs:
 # "A prefix to append to the filepath in the Binder links. You should use this

--- a/mne_nirs/datasets/fnirs_motor_group/fnirs_motor_group.py
+++ b/mne_nirs/datasets/fnirs_motor_group/fnirs_motor_group.py
@@ -55,11 +55,11 @@ def data_path(path=None, force_update=False, update_path=True, download=True,
     ----------
     .. footbibliography::
     """
-    ha = '2474b78640aa3e69a7eada881d0b275036d96e46'
+
     dataset_params = dict(
-        archive_name=f'BIDS-NIRS-Tapping-{ha}.zip',
-        hash='md5:18213355c2d83461c1799d6091f42946',
-        url=f'https://github.com/rob-luke/BIDS-NIRS-Tapping/archive/{ha}.zip',
+        archive_name='BIDS-NIRS-Tapping-master.zip',
+        hash='md5:5d9c5e231d735daa032d1c5708fcc1de',
+        url='https://github.com/rob-luke/BIDS-NIRS-Tapping/archive/master.zip',
         folder_name='fNIRS-motor-group',
         dataset_name='fnirs_motor_group',
         config_key='MNE_DATASETS_FNIRSMOTORGROUP_PATH',

--- a/mne_nirs/datasets/fnirs_motor_group/fnirs_motor_group.py
+++ b/mne_nirs/datasets/fnirs_motor_group/fnirs_motor_group.py
@@ -55,11 +55,11 @@ def data_path(path=None, force_update=False, update_path=True, download=True,
     ----------
     .. footbibliography::
     """
-
+    ha = '2474b78640aa3e69a7eada881d0b275036d96e46'
     dataset_params = dict(
-        archive_name='BIDS-NIRS-Tapping-master.zip',
-        hash='md5:d40529b85d4b7ebdf7243168c0e8c390',
-        url='https://github.com/rob-luke/BIDS-NIRS-Tapping/archive/master.zip',
+        archive_name=f'BIDS-NIRS-Tapping-{ha}.zip',
+        hash='md5:18213355c2d83461c1799d6091f42946',
+        url=f'https://github.com/rob-luke/BIDS-NIRS-Tapping/archive/{ha}.zip',
         folder_name='fNIRS-motor-group',
         dataset_name='fnirs_motor_group',
         config_key='MNE_DATASETS_FNIRSMOTORGROUP_PATH',

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -24,3 +24,4 @@ pysnirf2>=0.4.2
 statsmodels
 lets-plot; python_version < '3.10'
 dabest
+mne-qt-browser


### PR DESCRIPTION
New commit changed the hash of BIDS-NIRS-tapping

https://app.circleci.com/pipelines/github/mne-tools/mne-nirs/2245/workflows/eadc14d3-a7f8-4dcf-9adc-97b54a0d224a/jobs/2256

This also changes to using a fixed commit number (the new one) so that this won't happen again. If the new one doesn't work, I'll switch back. When the dataset is updated, a PR should be made here to update instead. (And the CircleCI cache number probably needs to be incremented.)