### PR TITLE
Don't require internal channel ordering

### DIFF
--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   # Linux
   job:
-    name: 'py3.8'
+    name: 'py3.10'
     runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, '[skip tests]')"
     defaults:
@@ -27,7 +27,7 @@ jobs:
       MNE_LOGGING_LEVEL: 'warning'
       MKL_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
-      PYTHON_VERSION: '3.9'
+      PYTHON_VERSION: '3.10'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/linux_pip.yml
+++ b/.github/workflows/linux_pip.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   # PIP + non-default stim channel + log level info
   job:
-    name: 'py3.9'
+    name: 'py3.10'
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -26,7 +26,7 @@ jobs:
       MNE_STIM_CHANNEL: 'STI101'
       OPENBLAS_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
-      PYTHON_VERSION: '3.9'  # dipy and vtk
+      PYTHON_VERSION: '3.10'
     strategy:
       matrix:
         MNEPYTHON: ['stable', 'dev']

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -29,11 +29,6 @@ def write_raw_snirf(raw, fname):
     picks = _picks_to_idx(raw.info, 'fnirs_cw_amplitude', exclude=[])
     assert len(picks) == len(raw.ch_names), 'Data must be fnirs_cw_amplitude'
 
-    # Reordering channels
-    num_chans = len(raw.ch_names)
-    raw = raw.copy()
-    raw.pick(picks=list(range(num_chans)[0::2]) + list(range(num_chans)[1::2]))
-
     with h5py.File(fname, 'w') as f:
         nirs = f.create_group('/nirs')
         f.create_dataset('formatVersion',

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -12,8 +12,10 @@ else
 	echo "Date utils"
 	# https://pip.pypa.io/en/latest/user_guide/#possible-ways-to-reduce-backtracking-occurring
 	pip install $STD_ARGS --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl six
-	echo "PyQt5"
-	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt5 PyQt5-sip PyQt5-Qt5
+        echo "PyQt6"
+	# XXX: the wheels for PyQt6-sip 13.4 are not available yet from https://www.riverbankcomputing.com/pypi/simple
+	# pip install $STD_ARGS --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6 PyQt6-sip PyQt6-Qt6
+	pip install $STD_ARGS --only-binary ":all:" PyQt6 PyQt6-sip PyQt6-Qt6
 	echo "NumPy/SciPy/pandas etc."
 	# TODO: Currently missing dipy for 3.10 https://github.com/dipy/dipy/issues/2489
 	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps  --default-timeout=60 -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy pandas scikit-learn statsmodels dipy
@@ -23,12 +25,9 @@ else
 	pip install $STD_ARGS --pre --only-binary ":all:" numba llvmlite https://github.com/nilearn/nilearn/zipball/main
 	echo "VTK"
 	# Have to use our own version until VTK releases a 3.10 build
-	if `python -c "import sys; assert sys.version_info >= (3, 10), sys.version_info"`; then
-		wget -q https://osf.io/hjyvx/download -O vtk-9.1.20211213.dev0-cp310-cp310-linux_x86_64.whl
-		pip install $STD_ARGS --pre --only-binary ":all:" vtk-9.1.20211213.dev0-cp310-cp310-linux_x86_64.whl
-	else
-		pip install $STD_ARGS --pre --only-binary ":all:" vtk
-	fi;
+	wget -q https://osf.io/ajder/download -O vtk-9.1.20220406.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+	pip install $STD_ARGS --pre --only-binary ":all:" vtk-9.1.20220406.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+	python -c "import vtk"
 	echo "PyVista"
 	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
 	echo "pyvistaqt"


### PR DESCRIPTION
#### Reference issue
Follows https://github.com/mne-tools/mne-python/pull/10642

#### What does this implement/fix?
No longer force reordering of SNIRF files.