### PR TITLE
documentation problems

### DIFF
--- a/doc/_static/versions.json
+++ b/doc/_static/versions.json
@@ -7,6 +7,6 @@
     {
         "name": "0.2.1 (stable)",
         "version": "stable",
-        "url": "https://mne.tools/mne-nirs/dev/"
+        "url": "https://mne.tools/mne-nirs/stable/"
     }
 ]


### PR DESCRIPTION
Fix versions dropdown.

@larsoner I have noticed that in the development docs it is not possible to click on any of the examples and view them in detail https://mne.tools/mne-nirs/dev/auto_examples/index.html 
I have checked this with two different browsers. Have you seen this issue before or have a hint what might be causing it?