### PR TITLE
FIX: Surface projection not working with HbR

### DIFF
--- a/mne_nirs/statistics/_glm_level_first.py
+++ b/mne_nirs/statistics/_glm_level_first.py
@@ -537,7 +537,7 @@ class RegressionResults(_BaseGLM):
         info = self.copy().pick(chroma).info
 
         return plot_glm_surface_projection(info, df, value="theta",
-                                           background=background,
+                                           picks=chroma, background=background,
                                            figure=figure, clim=clim,
                                            mode=mode, colormap=colormap,
                                            surface=surface, hemi=hemi,


### PR DESCRIPTION
#### Reference issue
Fixes #487.


#### What does this implement/fix?
Enable to plot the surface projection with HbR by passing *chroma* as *picks* parameter of the *plot_glm_surface_projection* in [surface_projection](https://mne.tools/mne-nirs/stable/_modules/mne_nirs/statistics/_glm_level_first.html#RegressionResults.surface_projection).