### PR TITLE
Fix SNIRF duration writing bug

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,7 +17,7 @@ To install a specific version of the library you would run ``pip install mne-nir
 v0.6.dev0
 ---------
 
-* Fix bug in SNIRF writter that caused incorrect duration to be written to file. By `Robert Luke`_.
+* Fix bug in SNIRF writer that caused incorrect duration to be written to file. By `Robert Luke`_.
 
 
 v0.5.0

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,7 +17,7 @@ To install a specific version of the library you would run ``pip install mne-nir
 v0.6.dev0
 ---------
 
-* Nothing yet
+* Fix bug in SNIRF writter that caused incorrect duration to be written to file. By `Robert Luke`_.
 
 
 v0.5.0

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -237,8 +237,9 @@ def _add_stim_info(raw, nirs):
         trgs = np.where(raw.annotations.description == desc)[0]
         stims = np.zeros((len(trgs), 3))
         for idx_t, trg in enumerate(trgs):
-            stims[idx_t, :] = [raw.annotations.onset[trg], 5.0,
-                               raw.annotations.duration[trg]]
+            stims[idx_t, :] = [raw.annotations.onset[trg],
+                               raw.annotations.duration[trg],
+                               idx]
         stim_group.create_dataset('data', data=stims)
         stim_group.create_dataset('name', data=_str_encode(desc))
 

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -5,7 +5,7 @@
 import os.path as op
 import datetime
 import h5py
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 import pandas as pd
 from snirf import validateSnirf
@@ -161,3 +161,47 @@ def test_aux_read():
     assert type(a) is pd.DataFrame
     assert 'accelerometer_2_z' in a
     assert len(a['gyroscope_1_z']) == len(raw.times)
+
+
+@requires_h5py
+@requires_testing_data
+@pytest.mark.parametrize('fname', (
+        fname_nirx_15_2,
+        fname_nirx_15_2_short,
+))
+def test_snirf_stim_roundtrip(fname, tmpdir):
+    """Ensure snirf annotations are written."""
+    raw_orig = read_raw_nirx(fname, preload=True)
+    assert raw_orig.annotations.duration[0] == 1
+    raw_mod = raw_orig.copy()
+    test_file = tmpdir.join('test_raw_no_mod.snirf')
+    write_raw_snirf(raw_mod, test_file)
+    raw = read_raw_snirf(test_file)
+    assert_array_equal(raw_orig.annotations.onset,
+                       raw.annotations.onset)
+    assert_array_equal(raw_orig.annotations.duration,
+                       raw.annotations.duration)
+    assert_array_equal(raw_orig.annotations.description,
+                       raw.annotations.description)
+
+
+@requires_h5py
+@requires_testing_data
+@pytest.mark.parametrize('fname', (
+        fname_nirx_15_2,
+        fname_nirx_15_2_short,
+))
+@pytest.mark.parametrize('newduration', (
+        1, 2, 3
+))
+def test_snirf_duration(fname, newduration, tmpdir):
+    """Ensure snirf annotations are written."""
+    raw_orig = read_raw_nirx(fname, preload=True)
+    assert raw_orig.annotations.duration[0] == 1
+    raw_mod = raw_orig.copy()
+    raw_mod.annotations.set_durations(newduration)
+    test_file = tmpdir.join('test_raw_duration.snirf')
+    write_raw_snirf(raw_mod, test_file)
+    raw = read_raw_snirf(test_file)
+    assert raw.annotations.duration[0] == newduration
+    assert raw.annotations.duration[-1] == newduration

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -16,6 +16,7 @@ from mne.io import read_raw_snirf, read_raw_nirx
 from mne_nirs.io.snirf import write_raw_snirf, SPEC_FORMAT_VERSION, \
     read_snirf_aux_data
 import mne_nirs.datasets.snirf_with_aux as aux
+from mne.utils import check_version
 
 
 fname_nirx_15_0 = op.join(data_path(download=False),
@@ -29,6 +30,8 @@ fname_snirf_aux = aux.data_path()
 
 pytest.importorskip('mne', '1.0')  # these tests are broken on 0.24!
 
+requires_mne_1_4 = pytest.mark.skipif(not check_version('mne', '1.4'),
+                                      reason='Needs MNE-Python 1.4')
 
 @requires_h5py
 @requires_testing_data
@@ -185,6 +188,7 @@ def test_snirf_stim_roundtrip(fname, tmpdir):
                        raw.annotations.description)
 
 
+@requires_mne_1_4
 @requires_h5py
 @requires_testing_data
 @pytest.mark.parametrize('fname', (

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -33,6 +33,7 @@ pytest.importorskip('mne', '1.0')  # these tests are broken on 0.24!
 requires_mne_1_4 = pytest.mark.skipif(not check_version('mne', '1.4'),
                                       reason='Needs MNE-Python 1.4')
 
+
 @requires_h5py
 @requires_testing_data
 @pytest.mark.parametrize('fname', (

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -166,8 +166,8 @@ def test_aux_read():
 @requires_h5py
 @requires_testing_data
 @pytest.mark.parametrize('fname', (
-        fname_nirx_15_2,
-        fname_nirx_15_2_short,
+    fname_nirx_15_2,
+    fname_nirx_15_2_short,
 ))
 def test_snirf_stim_roundtrip(fname, tmpdir):
     """Ensure snirf annotations are written."""
@@ -188,11 +188,11 @@ def test_snirf_stim_roundtrip(fname, tmpdir):
 @requires_h5py
 @requires_testing_data
 @pytest.mark.parametrize('fname', (
-        fname_nirx_15_2,
-        fname_nirx_15_2_short,
+    fname_nirx_15_2,
+    fname_nirx_15_2_short,
 ))
 @pytest.mark.parametrize('newduration', (
-        1, 2, 3
+    1, 2, 3
 ))
 def test_snirf_duration(fname, newduration, tmpdir):
     """Ensure snirf annotations are written."""

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -195,7 +195,7 @@ def test_snirf_stim_roundtrip(fname, tmpdir):
     1, 2, 3
 ))
 def test_snirf_duration(fname, newduration, tmpdir):
-    """Ensure snirf annotations are written."""
+    """Ensure snirf annotations are written to file."""
     raw_orig = read_raw_nirx(fname, preload=True)
     assert raw_orig.annotations.duration[0] == 1
     raw_mod = raw_orig.copy()

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,4 @@ lxml
 patsy
 tables
 typing_extensions
+seaborn


### PR DESCRIPTION
#### Reference issue
SNIRF file should write stims/annotations with the following format: `[starttime duration value]`.
As described here: https://github.com/fNIRS/snirf/blob/master/snirf_specification.md#nirsistimjdata

#### What does this implement/fix?
Modifes the `write_raw_snirf ` function to write stims according to the format above.
Added tests to ensure round trip read-write is lossless for stimulus parameters.


#### Additional information
This also requires a change to MNE here: https://github.com/mne-tools/mne-python/pull/11397