### PR TITLE
Add AtlasViewer compatible snirf export

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,6 +18,7 @@ v0.6.dev0
 ---------
 
 * Fix bug in SNIRF writer that caused incorrect duration to be written to file. By `Robert Luke`_.
+* Add option to export montage location in SNIRF using the landmarkLabels field. By `Robert Luke`_.
 
 
 v0.5.0

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -17,7 +17,7 @@ from mne.channels import make_standard_montage
 SPEC_FORMAT_VERSION = '1.0'
 
 
-def write_raw_snirf(raw, fname, atlasviewer=False):
+def write_raw_snirf(raw, fname, add_montage=False):
     """Write continuous wave data to disk in SNIRF format.
 
     Parameters
@@ -26,8 +26,8 @@ def write_raw_snirf(raw, fname, atlasviewer=False):
         Data to write to file. Must contain only `fnirs_cw_amplitude` type.
     fname : str
         Path to the SNIRF data file.
-    atlasviewer : bool
-        Should additional landmarks be exported to
+    add_montage : bool
+        Should the montage be added as landmarks to
         facilitate compatibility with AtlasViewer.
     """
 
@@ -41,7 +41,7 @@ def write_raw_snirf(raw, fname, atlasviewer=False):
 
         _add_metadata_tags(raw, nirs)
         _add_single_data_block(raw, nirs)
-        _add_probe_info(raw, nirs, atlasviewer=atlasviewer)
+        _add_probe_info(raw, nirs, add_montage=add_montage)
         _add_stim_info(raw, nirs)
 
 
@@ -158,7 +158,7 @@ def _add_measurement_lists(raw, data_block):
         ch_group.create_dataset('dataTypeIndex', data=1, dtype='int32')
 
 
-def _add_probe_info(raw, nirs, atlasviewer):
+def _add_probe_info(raw, nirs, add_montage):
     """Adds details of the probe to the nirs group.
 
     Parameters
@@ -167,8 +167,8 @@ def _add_probe_info(raw, nirs, atlasviewer):
         Data to add to the snirf file.
     nirs : hpy5.Group
         The root hdf5 nirs group to which the probe info should be added.
-    atlasviewer : bool
-        Should additional landmarks be exported to
+    add_montage : bool
+        Should the montage be added as landmarks to
         facilitate compatibility with AtlasViewer.
     """
     sources = _get_unique_source_list(raw)
@@ -200,10 +200,10 @@ def _add_probe_info(raw, nirs, atlasviewer):
 
     # Store probe landmarks
     if raw.info['dig'] is not None:
-        _store_probe_landmarks(raw, probe, atlasviewer)
+        _store_probe_landmarks(raw, probe, add_montage)
 
 
-def _store_probe_landmarks(raw, probe, atlasviewer):
+def _store_probe_landmarks(raw, probe, add_montage):
     """Adds the probe landmarks to the probe group.
 
     The SNIRF specification provides flexibility around
@@ -227,8 +227,8 @@ def _store_probe_landmarks(raw, probe, atlasviewer):
         Data to add to the snirf file.
     probe : hpy5.Group
         The hdf5 probe group to which the landmark info should be added.
-    atlasviewer : bool
-        Should additional landmarks be exported to
+    add_montage : bool
+        Should the montage be added as landmarks to
         facilitate compatibility with AtlasViewer.
     """
     diglocs = np.empty((len(raw.info['dig']), 3))
@@ -242,7 +242,7 @@ def _store_probe_landmarks(raw, probe, atlasviewer):
             digname.append(f"HP_{str(dig.get('ident'))}")
         diglocs[idx, :] = dig.get('r')
 
-    if atlasviewer:
+    if add_montage:
         # First, get the template positions in mni fsaverage space
         montage = make_standard_montage(
             'standard_1020', head_size=0.09700884729534559)

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -17,7 +17,7 @@ from mne.channels import make_standard_montage
 SPEC_FORMAT_VERSION = '1.0'
 
 
-def write_raw_snirf(raw, fname, atlasviewer):
+def write_raw_snirf(raw, fname, atlasviewer=False):
     """Write continuous wave data to disk in SNIRF format.
 
     Parameters
@@ -158,7 +158,7 @@ def _add_measurement_lists(raw, data_block):
         ch_group.create_dataset('dataTypeIndex', data=1, dtype='int32')
 
 
-def _add_probe_info(raw, nirs, atlasviewer=False):
+def _add_probe_info(raw, nirs, atlasviewer):
     """Adds details of the probe to the nirs group.
 
     Parameters

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -253,9 +253,8 @@ def _store_probe_landmarks(raw, probe, atlasviewer):
         head_mri_t, _ = _get_trans('fsaverage', 'mri', 'head')
         locations_head = apply_trans(head_mri_t, montage_locs)
 
-        for template_idx in range(len(ch_names)):
-            digname.append(ch_names[template_idx])
-            diglocs = np.vstack((diglocs, locations_head[template_idx, :]))
+        digname.extend(ch_names)
+        diglocs = np.concatenate((diglocs, locations_head))
 
     digname = [_str_encode(d) for d in digname]
     probe.create_dataset('landmarkPos3D', data=diglocs)

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -28,7 +28,7 @@ def write_raw_snirf(raw, fname, atlasviewer=False):
         Path to the SNIRF data file.
     atlasviewer : bool
         Should additional landmarks be exported to
-        facilitate compatability with AtlasViewer.
+        facilitate compatibility with AtlasViewer.
     """
 
     picks = _picks_to_idx(raw.info, 'fnirs_cw_amplitude', exclude=[])
@@ -169,7 +169,7 @@ def _add_probe_info(raw, nirs, atlasviewer):
         The root hdf5 nirs group to which the probe info should be added.
     atlasviewer : bool
         Should additional landmarks be exported to
-        facilitate compatability with AtlasViewer.
+        facilitate compatibility with AtlasViewer.
     """
     sources = _get_unique_source_list(raw)
     detectors = _get_unique_detector_list(raw)
@@ -229,7 +229,7 @@ def _store_probe_landmarks(raw, probe, atlasviewer):
         The hdf5 probe group to which the landmark info should be added.
     atlasviewer : bool
         Should additional landmarks be exported to
-        facilitate compatability with AtlasViewer.
+        facilitate compatibility with AtlasViewer.
     """
     diglocs = np.empty((len(raw.info['dig']), 3))
     digname = list()

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -10,10 +10,6 @@ import numpy as np
 from mne.io.pick import _picks_to_idx
 from mne.transforms import apply_trans, _get_trans
 from mne.channels import make_standard_montage
-from mne.io.constants import FIFF
-
-
-from ..fold._fold import _generate_montage_locations
 
 
 # The currently-implemented spec can be found here:

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -8,7 +8,7 @@ import h5py
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 import pandas as pd
-from pysnirf2 import validateSnirf, Snirf
+from snirf import validateSnirf, Snirf
 
 from mne.datasets.testing import data_path, requires_testing_data
 from mne.utils import requires_h5py, object_diff

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -107,11 +107,11 @@ def test_snirf_extra_atlasviewer(fname, tmpdir):
     raw_orig = read_raw_nirx(fname, preload=True)
     test_file = tmpdir.join('test_raw.snirf')
 
-    write_raw_snirf(raw_orig, test_file, atlasviewer=False)
+    write_raw_snirf(raw_orig, test_file, add_montage=False)
     raw = read_raw_snirf(test_file)
     assert len([i['ident'] for i in raw.info['dig']]) == 35
 
-    write_raw_snirf(raw_orig, test_file, atlasviewer=True)
+    write_raw_snirf(raw_orig, test_file, add_montage=True)
     raw = read_raw_snirf(test_file)
     assert len([i['ident'] for i in raw.info['dig']]) == 129
     snirf = Snirf(str(test_file), "r")

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ xlrd
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1
 traitlets
-pyvista>=0.32,!=0.35.2,!=0.38.0,!=0.38.1,!=0.38.2
+pyvista>=0.32,!=0.35.2,!=0.38.0,!=0.38.1,!=0.38.2,!=0.38.3
 pyvistaqt>=0.4
 mffpy>=0.5.7
 ipywidgets

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ xlrd
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1
 traitlets
-pyvista>=0.32
+pyvista>=0.32,!=0.35.2,!=0.38.0,!=0.38.1,!=0.38.2
 pyvistaqt>=0.4
 mffpy>=0.5.7
 ipywidgets


### PR DESCRIPTION
AtlasViewer required template positions to be exported in the `landmarkLabels` field to perform alignment. This PR provides an option to export those landmarks with the snirf writer.