### PR TITLE
MAINT: Update dependencies and revitalize the CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
               echo "export XDG_RUNTIME_DIR=/tmp/runtime-circleci" >> $BASH_ENV
               echo "export MNE_FULL_DATE=true" >> $BASH_ENV
-              echo "export MNE_3D_OPTION=false" >> $BASH_ENV
+              echo "export MNE_3D_OPTION=true" >> $BASH_ENV
               echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
               echo "source ~/python_env/bin/activate" >> $BASH_ENV
               mkdir -p ~/.local/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,10 @@ jobs:
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
               echo "export XDG_RUNTIME_DIR=/tmp/runtime-circleci" >> $BASH_ENV
               echo "export MNE_FULL_DATE=true" >> $BASH_ENV
-              echo "export MNE_3D_OPTION=true" >> $BASH_ENV
+              echo "export MNE_3D_BACKEND=pyvistaqt" >> $BASH_ENV
+              echo "export MNE_3D_OPTION_MULTI_SAMPLES=1" >> $BASH_ENV
+              echo "export MNE_BROWSER_BACKEND=qt" >> $BASH_ENV
+              echo "export MNE_BROWSER_PRECOMPUTE=false" >> $BASH_ENV
               echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
               echo "source ~/python_env/bin/activate" >> $BASH_ENV
               mkdir -p ~/.local/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ jobs:
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
               echo "export XDG_RUNTIME_DIR=/tmp/runtime-circleci" >> $BASH_ENV
               echo "export MNE_FULL_DATE=true" >> $BASH_ENV
+              echo "export MNE_3D_OPTION=false" >> $BASH_ENV
               echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
               echo "source ~/python_env/bin/activate" >> $BASH_ENV
               mkdir -p ~/.local/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       docker:
         # Use 18.04 rather than 20.04 because MESA 20.0.8 on 18.04 has working
         # transparency but 21.0.3 on 20.04 does not!
-        - image: cimg/base:stable-18.04
+        - image: cimg/base:2023.03-18.04
       steps:
         - restore_cache:
             keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,7 @@ _xvfb: &xvfb
 jobs:
     build_docs:
       docker:
-        # Use 18.04 rather than 20.04 because MESA 20.0.8 on 18.04 has working
-        # transparency but 21.0.3 on 20.04 does not!
-        - image: cimg/base:2023.03-18.04
+        - image: cimg/base:current-22.04
       steps:
         - restore_cache:
             keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,9 @@ jobs:
                 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
                 libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 \
                 graphviz optipng \
-                python3.8-venv python3-venv \
+                python3.10-venv python3-venv \
                 xvfb libxft2 ffmpeg
-              python3.8 -m venv ~/python_env
+              python3.10 -m venv ~/python_env
               echo "set -e" >> $BASH_ENV
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
               echo "export XDG_RUNTIME_DIR=/tmp/runtime-circleci" >> $BASH_ENV
@@ -98,7 +98,7 @@ jobs:
         - save_cache:
             key: user-install-bin-cache-0
             paths:
-              - ~/.local/lib/python3.8/site-packages
+              - ~/.local/lib/python3.10/site-packages
               - ~/.local/bin
 
         - run:

--- a/.github/workflows/linux_pip.yml
+++ b/.github/workflows/linux_pip.yml
@@ -27,6 +27,7 @@ jobs:
       OPENBLAS_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
       PYTHON_VERSION: '3.10'
+      QT_DEBUG_PLUGINS: '1'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux_pip.yml
+++ b/.github/workflows/linux_pip.yml
@@ -27,7 +27,6 @@ jobs:
       OPENBLAS_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
       PYTHON_VERSION: '3.10'
-      QT_DEBUG_PLUGINS: '1'
     strategy:
       fail-fast: false
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ ARG mne_nirs_v
 
 USER root
 
+RUN apt-get update && apt-get install -y --no-install-recommends git
 RUN pip install statsmodels dabest fooof h5io
-RUN pip install https://github.com/nilearn/nilearn/archive/${nilearn_v}.zip
-RUN pip install https://github.com/mne-tools/mne-bids/archive/${mne_bids_v}.zip
-RUN pip install https://github.com/mne-tools/mne-nirs/archive/${mne_nirs_v}.zip
+RUN pip install git+https://github.com/nilearn/nilearn.git@${nilearn_v}
+RUN pip install git+https://github.com/mne-tools/mne-bids.git@${mne_bids_v}
+RUN pip install git+https://github.com/mne-tools/mne-nirs.git@${mne_nirs_v}
 
 # Copy examples
 COPY ./ /home/mne_user/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,7 +77,7 @@ stages:
         architecture: 'x64'
         addToPath: true
       displayName: 'Get Python'
-    - bash: pip install --progress-bar off --upgrade -r requirements.txt -r requirements_testing.txt https://github.com/mne-tools/mne-python/zipball/main
+    - bash: pip install --progress-bar off --upgrade -r requirements.txt -r requirements_testing.txt git+https://github.com/mne-tools/mne-python.git@main
       displayName: Setup MNE-NIRS environment
     - script: pip install --progress-bar off -e .
       displayName: Install MNE-NIRS

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -142,7 +142,8 @@ html_theme_options = {
     ],
     "show_toc_level": 1,
     'navbar_end': ['theme-switcher', 'version-switcher', 'navbar-icon-links'],
-    'footer_items': ['copyright'],
+    'footer_start': ['copyright'],
+    'footer_end': [],
     'analytics': dict(google_analytics_id='UA-188272121-1'),
     'switcher': {
         'json_url': 'https://mne.tools/mne-nirs/dev/_static/versions.json',

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -49,8 +49,8 @@ If you need the latest version of MNE-Python or MNE-NIRS you can enter the follo
 
 .. code:: console
 
-   $ pip install -U --no-deps https://github.com/mne-tools/mne-python/archive/main.zip
-   $ pip install -U --no-deps https://github.com/mne-tools/mne-nirs/archive/main.zip
+   $ pip install -U --no-deps git+https://github.com/mne-tools/mne-python.git@main
+   $ pip install -U --no-deps git+https://github.com/mne-tools/mne-nirs.git@main
 
 
 Install via Conda or Pip
@@ -71,7 +71,7 @@ Or if you wish to run the latest development version of MNE-NIRS:
 
 .. code:: console
 
-    $ pip install https://github.com/mne-tools/mne-nirs/archive/main.zip
+    $ pip install git+https://github.com/mne-tools/mne-nirs.git@main
 
 
 Upgrading your software version
@@ -85,7 +85,7 @@ Similarly, you can update MNE-NIRS to the latest development version by running
 
 .. code:: console
 
-   $ pip install -U --no-deps https://github.com/mne-tools/mne-nirs/archive/main.zip
+   $ pip install -U --no-deps git+https://github.com/mne-tools/mne-nirs.git@main
 
 
 Acknowledgements

--- a/environment.yml
+++ b/environment.yml
@@ -44,4 +44,4 @@ dependencies:
 - mne-qt-browser
 - pymatreader
 - pip:
-  - https://github.com/mne-tools/mne-python/archive/main.zip
+  - git+https://github.com/mne-tools/mne-python.git@main

--- a/mne_nirs/statistics/_glm_level_first.py
+++ b/mne_nirs/statistics/_glm_level_first.py
@@ -359,7 +359,7 @@ class RegressionResults(_BaseGLM):
         Returns
         -------
         fig : figure
-            Figure of each design matrix componenent for hbo (top row)
+            Figure of each design matrix component for hbo (top row)
             and hbr (bottom row).
         """
         return _plot_glm_topo(self.info, self._data, self.design,
@@ -611,7 +611,7 @@ class ContrastResults(_BaseGLM):
         Returns
         -------
         fig : figure
-            Figure of each design matrix componenent for hbo (top row)
+            Figure of each design matrix component for hbo (top row)
             and hbr (bottom row).
         """
         return _plot_glm_contrast_topo(self.info, self._data,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # requirements for full MNE-Python functionality (other than raw/epochs export)
 numpy>=1.15.4
-scipy>=1.1.0
+scipy>=1.1.0,!=1.11.0.dev0
 matplotlib
 tqdm
 pooch>=1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ xlrd
 imageio>=2.6.1
 imageio-ffmpeg>=0.4.1
 traitlets
-pyvista>=0.32,!=0.35.2,!=0.38.0,!=0.38.1,!=0.38.2,!=0.38.3
+pyvista>=0.32,!=0.35.2,!=0.38.0,!=0.38.1,!=0.38.2,!=0.38.3,!=0.38.4,!=0.38.5
 pyvistaqt>=0.4
 mffpy>=0.5.7
 ipywidgets

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,8 +1,8 @@
 # requirements for building docs
 sphinx<6
-https://github.com/numpy/numpydoc/archive/main.zip
-https://github.com/pydata/pydata-sphinx-theme/archive/cef3e724e15852fc2a84bee256c457c9497834b8.zip
-https://github.com/sphinx-gallery/sphinx-gallery/archive/master.zip
+git+https://github.com/numpy/numpydoc.git@main
+pydata_sphinx_theme==0.13.1
+git+https://github.com/sphinx-gallery/sphinx-gallery@master
 sphinxcontrib-bibtex>=2.3
 memory_profiler
 seaborn

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -13,5 +13,5 @@ if [ ! -f /usr/lib/x86_64-linux-gnu/libxcb-util.so.1 ]; then
 fi
 
 python -m pip install --upgrade pip setuptools wheel
-python -m pip install --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt https://github.com/mne-tools/mne-python/zipball/main
+python -m pip install --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt git+https://github.com/mne-tools/mne-python.git@main
 python -m pip install -e .

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -29,7 +29,7 @@ else
 	pip install $STD_ARGS --pre --only-binary ":all:" vtk-9.1.20220406.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 	python -c "import vtk"
 	echo "PyVista"
-	pip install --progress-bar off git+https://github.com/pyvista/pyvista.git@main
+	pip install --progress-bar off pyvista==0.37.0
 	echo "pyvistaqt"
 	pip install --progress-bar off git+https://github.com/pyvista/pyvistaqt.git@main
 	echo "imageio-ffmpeg, xlrd, mffpy"

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -29,9 +29,9 @@ else
 	pip install $STD_ARGS --pre --only-binary ":all:" vtk-9.1.20220406.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 	python -c "import vtk"
 	echo "PyVista"
-	pip install --progress-bar off https://github.com/pyvista/pyvista/zipball/main
+	pip install --progress-bar off git+https://github.com/pyvista/pyvista.git@main
 	echo "pyvistaqt"
-	pip install --progress-bar off https://github.com/pyvista/pyvistaqt/zipball/main
+	pip install --progress-bar off git+https://github.com/pyvista/pyvistaqt.git@main
 	echo "imageio-ffmpeg, xlrd, mffpy"
 	pip install --progress-bar off --pre imageio-ffmpeg xlrd mffpy
 	if [ "$OSTYPE" == "darwin"* ]; then
@@ -47,7 +47,7 @@ else
 	MNE_BRANCH="maint/1.2"
 fi
 echo "MNE"
-pip install $STD_ARGS $EXTRA_ARGS https://github.com/mne-tools/mne-python/zipball/${MNE_BRANCH}
+pip install $STD_ARGS $EXTRA_ARGS git+https://github.com/mne-tools/mne-python.git@${MNE_BRANCH}
 
 if [ -z "$CONDA_ENV" ]; then
 	echo "requirements.txt"

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -29,9 +29,9 @@ else
 	pip install $STD_ARGS --pre --only-binary ":all:" vtk-9.1.20220406.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 	python -c "import vtk"
 	echo "PyVista"
-	pip install --progress-bar off git+https://github.com/pyvista/pyvista.git@main
+	pip install --progress-bar off git+https://github.com/pyvista/pyvista
 	echo "pyvistaqt"
-	pip install --progress-bar off git+https://github.com/pyvista/pyvistaqt.git@main
+	pip install --progress-bar off git+https://github.com/pyvista/pyvistaqt
 	echo "imageio-ffmpeg, xlrd, mffpy"
 	pip install --progress-bar off --pre imageio-ffmpeg xlrd mffpy
 	if [ "$OSTYPE" == "darwin"* ]; then

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -29,7 +29,7 @@ else
 	pip install $STD_ARGS --pre --only-binary ":all:" vtk-9.1.20220406.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 	python -c "import vtk"
 	echo "PyVista"
-	pip install --progress-bar off pyvista==0.37.0
+	pip install --progress-bar off git+https://github.com/pyvista/pyvista.git@main
 	echo "pyvistaqt"
 	pip install --progress-bar off git+https://github.com/pyvista/pyvistaqt.git@main
 	echo "imageio-ffmpeg, xlrd, mffpy"

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -11,5 +11,5 @@ done
 
 # This also includes the libraries necessary for PyQt5/PyQt6
 sudo apt update
-sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils libxcb-shape0
+sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils libxcb-shape0 libxcb-cursor0
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset


### PR DESCRIPTION
This PR fixes https://github.com/mne-tools/mne-nirs/issues/506 by introducing the following changes:
 - have pip install packages directly from `git` instead of GitHub tarballs or zipballs
 - replace `footer_items` (which is deprecated) with `footer_start` in `doc/conf.py`
 - fixes a typo
 - install `libxcb-cursor0` in addition to the rest of libxcb dependencies

These fixes were mostly adaptations of changes introduced by @larsoner in https://github.com/mne-tools/mne-python/

---
Contributed with ❤️ by AE Studio