### PR TITLE
Extend SNIRF support to v1.1

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -20,6 +20,7 @@ v0.6.dev0
 * Fix bug in SNIRF writer that caused incorrect duration to be written to file. By `Robert Luke`_.
 * Add option to export montage location in SNIRF using the landmarkLabels field. By `Robert Luke`_.
 * Fix continuous integration issues and update test infrastructure. By `Florin Pop`_.
+* SNIRF writer uses v1.1 of the spec by default. By `Florin Pop`_.
 
 
 v0.5.0

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -13,8 +13,8 @@ from mne.channels import make_standard_montage
 
 
 # The currently-implemented spec can be found here:
-# https://github.com/fNIRS/snirf/blob/52de9a6724ddd0c9dcd36d8d11007895fed74205/snirf_specification.md
-SPEC_FORMAT_VERSION = '1.0'
+# https://raw.githubusercontent.com/fNIRS/snirf/v1.1/snirf_specification.md
+SPEC_FORMAT_VERSION = '1.1'
 
 
 def write_raw_snirf(raw, fname, add_montage=False):

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -124,8 +124,8 @@ def test_snirf_extra_atlasviewer(fname, tmpdir):
 def _verify_snirf_required_fields(test_file):
     """Tests that all required fields are present.
 
-    Uses Draft 3 of version 1.0 of the spec:
-    https://github.com/fNIRS/snirf/blob/52de9a6724ddd0c9dcd36d8d11007895fed74205/snirf_specification.md
+    Uses version 1.1 of the spec:
+    https://raw.githubusercontent.com/fNIRS/snirf/v1.1/snirf_specification.md
     """
     required_metadata_fields = [
         'SubjectID', 'MeasurementDate', 'MeasurementTime',


### PR DESCRIPTION
 Fixes https://github.com/mne-tools/mne-nirs/issues/505

Writing data into the SNIRF format will use v1.1 of this spec by default.

The diff between v1.0 and v1.1: https://github.com/fNIRS/snirf/compare/v1.1..v1.0#diff-a6c853dca5f1a8eb3e37e0de75889250190b68f3597e91f33489a05874aa49c4

---
Contributed with ❤️ by AE Studio