### PR TITLE
MAINT: Migrate from PyQt5 to PySide6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
               set -e
               set -o pipefail
               ./tools/setup_xvfb.sh
+              sudo apt install -qq graphviz optipng python3.10-venv python3-venv libxft2 ffmpeg
               python3.10 -m venv ~/python_env
               echo "set -e" >> $BASH_ENV
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,6 @@
 # Tagging a commit with [circle full] will build everything.
 version: 2.1
 
-_xvfb: &xvfb
-  name: Start Xvfb virtual framebuffer
-  command: |
-    echo "export DISPLAY=:99" >> $BASH_ENV
-    /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1280x1024x24 -ac +extension GLX +render -noreset -nolisten tcp -nolisten unix
-
 jobs:
     build_docs:
       docker:
@@ -53,13 +47,8 @@ jobs:
             name: Set BASH_ENV
             command: |
               set -e
-              sudo apt update -qq
-              sudo apt install -qq libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 \
-                libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
-                libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 \
-                graphviz optipng \
-                python3.10-venv python3-venv \
-                xvfb libxft2 ffmpeg
+              set -o pipefail
+              ./tools/setup_xvfb.sh
               python3.10 -m venv ~/python_env
               echo "set -e" >> $BASH_ENV
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
@@ -69,6 +58,7 @@ jobs:
               echo "export MNE_3D_OPTION_MULTI_SAMPLES=1" >> $BASH_ENV
               echo "export MNE_BROWSER_BACKEND=qt" >> $BASH_ENV
               echo "export MNE_BROWSER_PRECOMPUTE=false" >> $BASH_ENV
+              echo "export DISPLAY=:99" >> $BASH_ENV
               echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
               echo "source ~/python_env/bin/activate" >> $BASH_ENV
               mkdir -p ~/.local/bin
@@ -77,9 +67,6 @@ jobs:
               cat $BASH_ENV
               mkdir -p ~/mne_data
               touch pattern.txt
-
-        - run:
-            <<: *xvfb
 
         # Load pip cache
         - restore_cache:
@@ -111,8 +98,8 @@ jobs:
               ./tools/fold.sh
 
         - run:
-            name: Check PyQt5
-            command: LD_DEBUG=libs python -c "from PyQt5.QtWidgets import QApplication, QWidget; app = QApplication([])"
+            name: Check Qt
+            command: LD_DEBUG=libs python -c "from PySide6.QtWidgets import QApplication, QWidget; app = QApplication([])"
 
         # Look at what we have and fail early if there is some library conflict
         # (remove irrelevant lines compared to MNE-Python)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -21,7 +21,7 @@ v0.6.dev0
 * Add option to export montage location in SNIRF using the landmarkLabels field. By `Robert Luke`_.
 * Fix continuous integration issues and update test infrastructure. By `Florin Pop`_.
 * SNIRF writer uses v1.1 of the spec by default. By `Florin Pop`_.
-
+* Migrate from PyQt5/PyQt6 to PySide6. By `Florin Pop`_.
 
 v0.5.0
 ------

--- a/mne_nirs/tests/test_examples.py
+++ b/mne_nirs/tests/test_examples.py
@@ -28,8 +28,8 @@ def examples_path():
 
 def run_script_and_check(test_file_path):
     with open(test_file_path) as fid, warnings.catch_warnings():
-        # Ignore deprecation warning caused by setting app.setAttribute(Qt.AA_UseHighDpiPixmaps)
-        # in mne-python
+        # Ignore deprecation warning caused by
+        # app.setAttribute(Qt.AA_UseHighDpiPixmaps) in mne-python
         warnings.filterwarnings("ignore", category=DeprecationWarning)
         return exec(fid.read(), locals(), locals())
 

--- a/mne_nirs/tests/test_examples.py
+++ b/mne_nirs/tests/test_examples.py
@@ -7,6 +7,7 @@
 import os
 import pytest
 import sys
+import warnings
 
 from mne.utils import check_version
 
@@ -26,7 +27,10 @@ def examples_path():
 
 
 def run_script_and_check(test_file_path):
-    with open(test_file_path) as fid:
+    with open(test_file_path) as fid, warnings.catch_warnings():
+        # Ignore deprecation warning caused by setting app.setAttribute(Qt.AA_UseHighDpiPixmaps)
+        # in mne-python
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         return exec(fid.read(), locals(), locals())
 
 

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -34,8 +34,8 @@ def test_plot_nirs_source_detector_pyvista(requires_pyvista):
     raw = mne.io.read_raw_nirx(raw_path)
 
     with warnings.catch_warnings():
-        # Ignore deprecation warning caused by setting app.setAttribute(Qt.AA_UseHighDpiPixmaps)
-        # in mne-python
+        # Ignore deprecation warning caused by
+        # app.setAttribute(Qt.AA_UseHighDpiPixmaps) in mne-python
         warnings.filterwarnings("ignore", category=DeprecationWarning)
         mne_nirs.visualisation.plot_nirs_source_detector(
             np.random.randn(len(raw.ch_names)),
@@ -143,8 +143,8 @@ def test_run_plot_GLM_projection(requires_pyvista):
     df = df.query("Condition in 'A'")
 
     with warnings.catch_warnings():
-        # Ignore deprecation warning caused by setting app.setAttribute(Qt.AA_UseHighDpiPixmaps)
-        # in mne-python
+        # Ignore deprecation warning caused by
+        # app.setAttribute(Qt.AA_UseHighDpiPixmaps) in mne-python
         warnings.filterwarnings("ignore", category=DeprecationWarning)
         brain = plot_glm_surface_projection(raw_haemo.copy().pick("hbo"),
                                             df, clim='auto', view='dorsal',
@@ -178,8 +178,8 @@ def test_plot_3d_montage(requires_pyvista, fname_raw, to_1020, ch_names):
     # We use "sample" here even though it's wrong so that we can have a head
     # surface
     with catch_logging() as log, warnings.catch_warnings():
-        # Ignore deprecation warning caused by setting app.setAttribute(Qt.AA_UseHighDpiPixmaps)
-        # in mne-python
+        # Ignore deprecation warning caused by
+        # app.setAttribute(Qt.AA_UseHighDpiPixmaps) in mne-python
         warnings.filterwarnings("ignore", category=DeprecationWarning)
         mne_nirs.viz.plot_3d_montage(
             raw.info, view_map, subject='sample', surface='white',
@@ -198,10 +198,10 @@ def test_plot_3d_montage(requires_pyvista, fname_raw, to_1020, ch_names):
 def test_glm_surface_projection(requires_pyvista):
     res = _get_glm_result(tmax=2974, tmin=0)
     with warnings.catch_warnings():
-        # Ignore deprecation warning caused by setting app.setAttribute(Qt.AA_UseHighDpiPixmaps)
-        # in mne-python
+        # Ignore deprecation warning caused by
+        # app.setAttribute(Qt.AA_UseHighDpiPixmaps) in mne-python
         warnings.filterwarnings("ignore", category=DeprecationWarning)
-        res.surface_projection(condition="e3p0", view="dorsal", surface="white",
-                            subjects_dir=subjects_dir)
+        res.surface_projection(condition="e3p0", view="dorsal",
+                               surface="white", subjects_dir=subjects_dir)
     with pytest.raises(KeyError, match='not found in conditions'):
         res.surface_projection(condition='foo')

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -8,6 +8,7 @@ import pytest
 import numpy as np
 import mne
 import mne_nirs
+import warnings
 
 from mne.datasets import testing
 from mne.utils import catch_logging, check_version
@@ -32,25 +33,29 @@ requires_mne_1 = pytest.mark.skipif(not check_version('mne', '1.0'),
 def test_plot_nirs_source_detector_pyvista(requires_pyvista):
     raw = mne.io.read_raw_nirx(raw_path)
 
-    mne_nirs.visualisation.plot_nirs_source_detector(
-        np.random.randn(len(raw.ch_names)),
-        raw.info, show_axes=True,
-        subject='fsaverage',
-        trans='fsaverage',
-        surfaces=['white'],
-        fnirs=False,
-        subjects_dir=subjects_dir,
-        verbose=True)
+    with warnings.catch_warnings():
+        # Ignore deprecation warning caused by setting app.setAttribute(Qt.AA_UseHighDpiPixmaps)
+        # in mne-python
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        mne_nirs.visualisation.plot_nirs_source_detector(
+            np.random.randn(len(raw.ch_names)),
+            raw.info, show_axes=True,
+            subject='fsaverage',
+            trans='fsaverage',
+            surfaces=['white'],
+            fnirs=False,
+            subjects_dir=subjects_dir,
+            verbose=True)
 
-    mne_nirs.visualisation.plot_nirs_source_detector(
-        np.abs(np.random.randn(len(raw.ch_names))) + 5,
-        raw.info, show_axes=True,
-        subject='fsaverage',
-        trans='fsaverage',
-        surfaces=['white'],
-        fnirs=False,
-        subjects_dir=subjects_dir,
-        verbose=True)
+        mne_nirs.visualisation.plot_nirs_source_detector(
+            np.abs(np.random.randn(len(raw.ch_names))) + 5,
+            raw.info, show_axes=True,
+            subject='fsaverage',
+            trans='fsaverage',
+            surfaces=['white'],
+            fnirs=False,
+            subjects_dir=subjects_dir,
+            verbose=True)
 
 
 def test_run_plot_GLM_topo():
@@ -137,12 +142,16 @@ def test_run_plot_GLM_projection(requires_pyvista):
     df = df.query("Chroma in 'hbo'")
     df = df.query("Condition in 'A'")
 
-    brain = plot_glm_surface_projection(raw_haemo.copy().pick("hbo"),
-                                        df, clim='auto', view='dorsal',
-                                        colorbar=True, size=(800, 700),
-                                        value="theta", surface='white',
-                                        subjects_dir=subjects_dir)
-    assert type(brain) == mne.viz._brain.Brain
+    with warnings.catch_warnings():
+        # Ignore deprecation warning caused by setting app.setAttribute(Qt.AA_UseHighDpiPixmaps)
+        # in mne-python
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        brain = plot_glm_surface_projection(raw_haemo.copy().pick("hbo"),
+                                            df, clim='auto', view='dorsal',
+                                            colorbar=True, size=(800, 700),
+                                            value="theta", surface='white',
+                                            subjects_dir=subjects_dir)
+        assert type(brain) == mne.viz._brain.Brain
 
 
 @requires_mne_1
@@ -168,7 +177,10 @@ def test_plot_3d_montage(requires_pyvista, fname_raw, to_1020, ch_names):
                 'caudal': np.arange(n_labels // 2, n_labels + 1)}
     # We use "sample" here even though it's wrong so that we can have a head
     # surface
-    with catch_logging() as log:
+    with catch_logging() as log, warnings.catch_warnings():
+        # Ignore deprecation warning caused by setting app.setAttribute(Qt.AA_UseHighDpiPixmaps)
+        # in mne-python
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         mne_nirs.viz.plot_3d_montage(
             raw.info, view_map, subject='sample', surface='white',
             subjects_dir=subjects_dir, ch_names=ch_names, verbose=True)
@@ -184,9 +196,12 @@ def test_plot_3d_montage(requires_pyvista, fname_raw, to_1020, ch_names):
 @pytest.mark.skipif(not check_version('mne', '1.0'),
                     reason='Needs MNE-Python 1.0')
 def test_glm_surface_projection(requires_pyvista):
-
     res = _get_glm_result(tmax=2974, tmin=0)
-    res.surface_projection(condition="e3p0", view="dorsal", surface="white",
-                           subjects_dir=subjects_dir)
+    with warnings.catch_warnings():
+        # Ignore deprecation warning caused by setting app.setAttribute(Qt.AA_UseHighDpiPixmaps)
+        # in mne-python
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        res.surface_projection(condition="e3p0", view="dorsal", surface="white",
+                            subjects_dir=subjects_dir)
     with pytest.raises(KeyError, match='not found in conditions'):
         res.surface_projection(condition='foo')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,7 @@ decorator
 h5io
 packaging
 pymatreader
-pyqt5>=5.10,<5.14; platform_system == "Darwin"
-pyqt5>=5.10,!=5.15.2,!=5.15.3; platform_system == "Linux"
-pyqt5>=5.10,!=5.15.3; platform_system == "Windows"
-pyqt5-sip
+pyside6
 pyobjc-framework-Cocoa>=5.2.0; platform_system=="Darwin"
 sip
 scikit-learn

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -1,16 +1,5 @@
 #!/bin/bash -ef
 
-echo "Working around PyQt5 bugs"
-# https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
-# https://github.com/golemfactory/golem/issues/1019
-sudo apt update
-sudo apt install libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 \
-	libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
-	libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 \
-	graphviz optipng
-if [ ! -f /usr/lib/x86_64-linux-gnu/libxcb-util.so.1 ]; then
-	sudo ln -s /usr/lib/x86_64-linux-gnu/libxcb-util.so.0 /usr/lib/x86_64-linux-gnu/libxcb-util.so.1
-fi
 
 python -m pip install --upgrade pip setuptools wheel
 python -m pip install --upgrade --progress-bar off -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt git+https://github.com/mne-tools/mne-python.git@main

--- a/tools/github_actions_dependencies.sh
+++ b/tools/github_actions_dependencies.sh
@@ -12,10 +12,8 @@ else
 	echo "Date utils"
 	# https://pip.pypa.io/en/latest/user_guide/#possible-ways-to-reduce-backtracking-occurring
 	pip install $STD_ARGS --pre --only-binary ":all:" python-dateutil pytz joblib threadpoolctl six
-        echo "PyQt6"
-	# XXX: the wheels for PyQt6-sip 13.4 are not available yet from https://www.riverbankcomputing.com/pypi/simple
-	# pip install $STD_ARGS --pre --only-binary ":all:" --no-deps --extra-index-url https://www.riverbankcomputing.com/pypi/simple PyQt6 PyQt6-sip PyQt6-Qt6
-	pip install $STD_ARGS --only-binary ":all:" PyQt6 PyQt6-sip PyQt6-Qt6
+    echo "pyside6"
+	pip install $STD_ARGS --pre --only-binary ":all:" pyside6
 	echo "NumPy/SciPy/pandas etc."
 	# TODO: Currently missing dipy for 3.10 https://github.com/dipy/dipy/issues/2489
 	pip install $STD_ARGS --pre --only-binary ":all:" --no-deps  --default-timeout=60 -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy scipy pandas scikit-learn statsmodels dipy

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -9,7 +9,7 @@ for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do
     sudo rm $apt_file
 done
 
-# This also includes the libraries necessary for PyQt5/PyQt6
+# This also includes the libraries necessary for PyQt6
 sudo apt update
 sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils libxcb-shape0 libxcb-cursor0
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -9,7 +9,7 @@ for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do
     sudo rm $apt_file
 done
 
-# This also includes the libraries necessary for PyQt6
+# This also includes the libraries necessary for pyside6
 sudo apt update
 sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils libxcb-shape0 libxcb-cursor0
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset


### PR DESCRIPTION
Fixes https://github.com/mne-tools/mne-nirs/issues/471 by:
- replacing `PyQt5` with `pyside6` in `requirements.txt `which is also used by Circle CI / Azure pipelines
- replacing `PyQt6` with `pyside6` for github workflows
- adding a mitigation for ensuring that some tests are not failing due to a QT deprecation warning


---
Contributed with ❤️ by AE Studio