### PR TITLE
Write optical density data in SNIRF format

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -22,6 +22,7 @@ v0.6.dev0
 * Fix continuous integration issues and update test infrastructure. By `Florin Pop`_.
 * SNIRF writer uses v1.1 of the spec by default. By `Florin Pop`_.
 * Migrate from PyQt5/PyQt6 to PySide6. By `Florin Pop`_.
+* Write optical density data in SNIRF format. By `Florin Pop`_.
 
 v0.5.0
 ------

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -280,3 +280,4 @@ def test_optical_density_roundtrip(fname, tmpdir):
                        od.annotations.duration)
     assert_array_equal(od_orig.annotations.description,
                        od.annotations.description)
+    assert_array_equal(od_orig.get_data(), od.get_data())

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -98,7 +98,7 @@ def test_snirf_write_optical_density(fname, tmpdir):
     write_raw_snirf(od_orig, test_file)
     od = read_raw_snirf(test_file)
     assert 'fnirs_od' in od
-    
+
     result = validateSnirf(str(test_file))
     if result.is_valid():
         result.display()

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -13,6 +13,7 @@ from snirf import validateSnirf, Snirf
 from mne.datasets.testing import data_path, requires_testing_data
 from mne.utils import requires_h5py, object_diff
 from mne.io import read_raw_snirf, read_raw_nirx
+from mne.preprocessing.nirs import optical_density
 from mne_nirs.io.snirf import write_raw_snirf, SPEC_FORMAT_VERSION, \
     read_snirf_aux_data
 import mne_nirs.datasets.snirf_with_aux as aux
@@ -234,3 +235,26 @@ def test_snirf_duration(fname, newduration, tmpdir):
     raw = read_raw_snirf(test_file)
     assert raw.annotations.duration[0] == newduration
     assert raw.annotations.duration[-1] == newduration
+
+
+@requires_h5py
+@requires_testing_data
+@pytest.mark.parametrize('fname', (
+    fname_nirx_15_2,
+    fname_nirx_15_2_short,
+))
+def test_optical_density_roundtrip(fname, tmpdir):
+    """Ensure snirf annotations are written."""
+    raw_nirx = read_raw_nirx(fname, preload=True)
+    od_orig = optical_density(raw_nirx)
+    assert od_orig.annotations.duration[0] == 1
+    test_file = tmpdir.join('test_raw_no_mod.snirf')
+    write_raw_snirf(od_orig, test_file)
+    od = read_raw_snirf(test_file)
+    assert 'fnirs_od' in od
+    assert_array_equal(od_orig.annotations.onset,
+                       od.annotations.onset)
+    assert_array_equal(od_orig.annotations.duration,
+                       od.annotations.duration)
+    assert_array_equal(od_orig.annotations.description,
+                       od.annotations.description)

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -42,7 +42,7 @@ requires_mne_1_4 = pytest.mark.skipif(not check_version('mne', '1.4'),
     fname_nirx_15_2,
     fname_nirx_15_0
 ))
-def test_snirf_write(fname, tmpdir):
+def test_snirf_write_raw(fname, tmpdir):
     """Test reading NIRX files."""
     raw_orig = read_raw_nirx(fname, preload=True)
     test_file = tmpdir.join('test_raw.snirf')
@@ -81,6 +81,28 @@ def test_snirf_write(fname, tmpdir):
 
     _verify_snirf_required_fields(test_file)
     _verify_snirf_version_str(test_file)
+
+
+@requires_h5py
+@requires_testing_data
+@pytest.mark.parametrize('fname', (
+    fname_nirx_15_2_short,
+    fname_nirx_15_2,
+    fname_nirx_15_0
+))
+def test_snirf_write_optical_density(fname, tmpdir):
+    """Test writing optical density SNIRF files."""
+    raw_nirx = read_raw_nirx(fname, preload=True)
+    od_orig = optical_density(raw_nirx)
+    test_file = tmpdir.join('test_od.snirf')
+    write_raw_snirf(od_orig, test_file)
+    od = read_raw_snirf(test_file)
+    assert 'fnirs_od' in od
+    
+    result = validateSnirf(str(test_file))
+    if result.is_valid():
+        result.display()
+    assert result.is_valid()
 
 
 @requires_h5py

--- a/mne_nirs/statistics/tests/test_glm_type.py
+++ b/mne_nirs/statistics/tests/test_glm_type.py
@@ -12,6 +12,7 @@ from matplotlib.pyplot import Axes
 
 import mne
 from mne.datasets import testing
+from mne.fixes import _compare_version
 import nilearn
 
 from mne_nirs.statistics import RegressionResults, read_glm
@@ -111,8 +112,14 @@ def test_results_glm_properties():
     assert len(res.copy().pick(picks="S1_D1 hbr")) == 1
     assert len(res.copy().pick(picks=["S1_D1 hbr"])) == 1
     assert len(res.copy().pick(picks=["S1_D1 hbr", "S1_D1 hbo"])) == 2
-    with pytest.raises(RuntimeWarning, match='could not be picked'):
+
+    if _compare_version(mne.__version__, '>=', '1.4'):
+        ctx = pytest.raises(ValueError, match='could not be picked')
+    else:
+        ctx = pytest.warns(RuntimeWarning, match='could not be picked')
+    with ctx:
         assert len(res.copy().pick(picks=["S1_D1 hbr", "S1_D1 XXX"])) == 1
+
     assert len(res.copy().pick(picks="fnirs")) == n_channels
     assert len(res.copy().pick(picks="hbo")) == n_channels / 2
     assert len(res.copy().pick(picks="hbr")) == n_channels / 2

--- a/mne_nirs/statistics/tests/test_glm_type.py
+++ b/mne_nirs/statistics/tests/test_glm_type.py
@@ -113,10 +113,10 @@ def test_results_glm_properties():
     assert len(res.copy().pick(picks=["S1_D1 hbr"])) == 1
     assert len(res.copy().pick(picks=["S1_D1 hbr", "S1_D1 hbo"])) == 2
 
-    if _compare_version(mne.__version__, '>=', '1.4'):
-        ctx = pytest.raises(ValueError, match='could not be picked')
-    else:
+    if _compare_version(mne.__version__, '<', '1.4'):
         ctx = pytest.warns(RuntimeWarning, match='could not be picked')
+    else:
+        ctx = pytest.raises(ValueError, match='could not be picked')
     with ctx:
         assert len(res.copy().pick(picks=["S1_D1 hbr", "S1_D1 XXX"])) == 1
 

--- a/mne_nirs/statistics/tests/test_glm_type.py
+++ b/mne_nirs/statistics/tests/test_glm_type.py
@@ -113,7 +113,7 @@ def test_results_glm_properties():
     assert len(res.copy().pick(picks=["S1_D1 hbr"])) == 1
     assert len(res.copy().pick(picks=["S1_D1 hbr", "S1_D1 hbo"])) == 2
 
-    if _compare_version(mne.__version__, '<', '1.4'):
+    if _compare_version(mne.__version__, '<', '1.4.0.dev140'):
         ctx = pytest.warns(RuntimeWarning, match='could not be picked')
     else:
         ctx = pytest.raises(ValueError, match='could not be picked')


### PR DESCRIPTION
Fixes https://github.com/mne-tools/mne-nirs/issues/456

Write optical density data in SNIRF format. 

Example usage:

```python
# %%
import os
import mne
import snirf

from mne.io import read_raw_nirx, read_raw_snirf
from mne_nirs.io import write_raw_snirf
from mne.preprocessing.nirs import optical_density
from numpy.testing import assert_allclose


# %%
# Import raw NIRS data from vendor
# --------------------------------
#
# First we import some example data recorded with a NIRX device.


fnirs_data_folder = mne.datasets.fnirs_motor.data_path()
fnirs_raw_dir = os.path.join(fnirs_data_folder, 'Participant-1')
raw_intensity = read_raw_nirx(fnirs_raw_dir).load_data()

# %%
# Convert to optical density

raw_od = optical_density(raw_intensity)

# %%
# Write data as SNIRF
# -------------------
#
# Now we can write this data back to disk in the SNIRF format.

write_raw_snirf(raw_od, 'test_raw.snirf')


# %%
# Read back SNIRF file
# --------------------
# 
# Next we can read back the snirf file.

snirf_intensity = read_raw_snirf('test_raw.snirf')


# %%
# Compare files
# -------------
# 
# Finally we can compare the data of the original to the SNIRF format and
# ensure that the values are the same.

assert_allclose(raw_od.get_data(), snirf_intensity.get_data())

snirf_intensity.plot(n_channels=30, duration=300, show_scrollbars=False)


# %%
# Validate SNIRF File
# -------------------
#
# To validate that a file complies with the SNIRF standard you should use the
# official SNIRF validator from the Boston University Neurophotonics Center
# called ``snirf``. Detailed instructions for this program can be found at
# https://github.com/BUNPC/pysnirf2. Below we demonstrate that the files created
# by MNE-NIRS are compliant with the specification.

result = snirf.validateSnirf('test_raw.snirf')
assert result.is_valid()
result.display()

```

---
Contributed with ❤️ by AE Studio