### PR TITLE
Fix Series.__getitem__ FutureWarning

### DIFF
--- a/mne_nirs/statistics/_statsmodels.py
+++ b/mne_nirs/statistics/_statsmodels.py
@@ -111,7 +111,7 @@ def statsmodels_to_results(model, order=None):
         for i in range(model.k_re):
             for j in range(i + 1):
                 sdf[jj, 0] = np.asarray(model.cov_re)[i, j]
-                sdf[jj, 1] = np.sqrt(model.scale) * model.bse[model.k_fe + jj]
+                sdf[jj, 1] = np.sqrt(model.scale) * model.bse.iloc[model.k_fe + jj]
                 jj += 1
 
         # Variance components

--- a/mne_nirs/statistics/_statsmodels.py
+++ b/mne_nirs/statistics/_statsmodels.py
@@ -112,7 +112,7 @@ def statsmodels_to_results(model, order=None):
             for j in range(i + 1):
                 sdf[jj, 0] = np.asarray(model.cov_re)[i, j]
                 sdf[jj, 1] = np.sqrt(model.scale) * \
-                             model.bse.iloc[model.k_fe + jj]
+                    model.bse.iloc[model.k_fe + jj]
                 jj += 1
 
         # Variance components

--- a/mne_nirs/statistics/_statsmodels.py
+++ b/mne_nirs/statistics/_statsmodels.py
@@ -111,7 +111,8 @@ def statsmodels_to_results(model, order=None):
         for i in range(model.k_re):
             for j in range(i + 1):
                 sdf[jj, 0] = np.asarray(model.cov_re)[i, j]
-                sdf[jj, 1] = np.sqrt(model.scale) * model.bse.iloc[model.k_fe + jj]
+                sdf[jj, 1] = np.sqrt(model.scale) * \
+                             model.bse.iloc[model.k_fe + jj]
                 jj += 1
 
         # Variance components


### PR DESCRIPTION
Fixes error...

```
________________________ test_statsmodel_to_df[mixedlm] ________________________
mne_nirs/statistics/tests/test_statsmodels.py:47: in test_statsmodel_to_df
    df = statsmodels_to_results(roi_model)
mne_nirs/statistics/_statsmodels.py:114: in statsmodels_to_results
    sdf[jj, 1] = np.sqrt(model.scale) * model.bse[model.k_fe + jj]
/opt/hostedtoolcache/Python/3.10.11/x64/lib/python3.10/site-packages/pandas/core/series.py:976: in __getitem__
    warnings.warn(
E   FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
```