### PR TITLE
MAINT: Remove deprecated requires_module

### DIFF
--- a/.github/workflows/CircleCI_PR.yml
+++ b/.github/workflows/CircleCI_PR.yml
@@ -1,18 +1,15 @@
 on: [status]
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.type }}
-  cancel-in-progress: true
-
 jobs:
   circleci_artifacts_redirector_job:
+    if: "${{ startsWith(github.event.context, 'ci/circleci: build_docs') }}"
     runs-on: ubuntu-20.04
     name: Run CircleCI artifacts redirector
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: GitHub Action step
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_TOKEN }}
           artifact-path: 0/html/index.html
           circleci-jobs: build_docs
+          job-title: Check the rendered docs here!

--- a/examples/general/plot_80_save_read_glm.py
+++ b/examples/general/plot_80_save_read_glm.py
@@ -167,7 +167,7 @@ for sub in subjects:
     save_path = save_path.update(subject=sub)
 
     # Read the data
-    results = read_glm(save_path)
+    results = read_glm(save_path.fpath)
 
     # Extract results from data as dataframe
     individual_results = results.to_dataframe()

--- a/mne_nirs/conftest.py
+++ b/mne_nirs/conftest.py
@@ -42,6 +42,8 @@ def pytest_configure(config):
     ignore:.*is not yet supported for.*in qdarkstyle.*:RuntimeWarning
     always::ResourceWarning
     ignore:_SixMetaPathImporter.find_spec\(\) not found.*:ImportWarning
+    # seaborn
+    ignore:The register_cmap function.*:
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()
@@ -106,6 +108,8 @@ def options_3d():
 def requires_pyvista(options_3d):
     pyvista = pytest.importorskip('pyvista')
     pytest.importorskip('pyvistaqt')
+    pyvista.close_all()
+    assert len(pyvista.plotting._ALL_PLOTTERS) == 0
     mne.viz.set_3d_backend('pyvista')
-    yield
+    yield pyvista
     pyvista.close_all()

--- a/mne_nirs/conftest.py
+++ b/mne_nirs/conftest.py
@@ -44,6 +44,7 @@ def pytest_configure(config):
     ignore:_SixMetaPathImporter.find_spec\(\) not found.*:ImportWarning
     # seaborn
     ignore:The register_cmap function.*:
+    ignore:The get_cmap function.*:
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()
@@ -109,7 +110,12 @@ def requires_pyvista(options_3d):
     pyvista = pytest.importorskip('pyvista')
     pytest.importorskip('pyvistaqt')
     pyvista.close_all()
-    assert len(pyvista.plotting._ALL_PLOTTERS) == 0
+    try:
+        from pyvista.plotting.plotter import _ALL_PLOTTERS
+    except Exception:  # PV < 0.40
+        from pyvista.plotting.plotting import _ALL_PLOTTERS
+    assert len(_ALL_PLOTTERS) == 0
     mne.viz.set_3d_backend('pyvista')
     yield pyvista
     pyvista.close_all()
+    assert len(_ALL_PLOTTERS) == 0

--- a/mne_nirs/conftest.py
+++ b/mne_nirs/conftest.py
@@ -45,6 +45,8 @@ def pytest_configure(config):
     # seaborn
     ignore:The register_cmap function.*:
     ignore:The get_cmap function.*:
+    # old MNE
+    ignore:The `pyvista.plotting.plotting` module.*:
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne_nirs/conftest.py
+++ b/mne_nirs/conftest.py
@@ -42,9 +42,12 @@ def pytest_configure(config):
     ignore:.*is not yet supported for.*in qdarkstyle.*:RuntimeWarning
     always::ResourceWarning
     ignore:_SixMetaPathImporter.find_spec\(\) not found.*:ImportWarning
+    # Should probably fix these at some point...
+    ignore:unclosed file.*:ResourceWarning
     # seaborn
     ignore:The register_cmap function.*:
     ignore:The get_cmap function.*:
+    ignore:The figure layout has changed.*:UserWarning
     # old MNE
     ignore:The `pyvista.plotting.plotting` module.*:
     """  # noqa: E501

--- a/mne_nirs/experimental_design/_experimental_design.py
+++ b/mne_nirs/experimental_design/_experimental_design.py
@@ -122,8 +122,7 @@ def create_boxcar(raw, event_id=None, stim_dur=1):
     s : array
         Returns an array for each annotation label.
     """
-    from scipy.signal import windows
-    bc = windows.boxcar(round(raw.info['sfreq'] * stim_dur))
+    bc = np.ones(round(raw.info['sfreq'] * stim_dur))
     events, ids = mne.events_from_annotations(raw, event_id=event_id)
     s = np.zeros((len(raw.times), len(ids)))
     for idx, id in enumerate(ids):

--- a/mne_nirs/experimental_design/_experimental_design.py
+++ b/mne_nirs/experimental_design/_experimental_design.py
@@ -122,8 +122,8 @@ def create_boxcar(raw, event_id=None, stim_dur=1):
     s : array
         Returns an array for each annotation label.
     """
-    from scipy import signal
-    bc = signal.boxcar(round(raw.info['sfreq'] * stim_dur))
+    from scipy.signal import windows
+    bc = windows.boxcar(round(raw.info['sfreq'] * stim_dur))
     events, ids = mne.events_from_annotations(raw, event_id=event_id)
     s = np.zeros((len(raw.times), len(ids)))
     for idx, id in enumerate(ids):

--- a/mne_nirs/experimental_design/_experimental_design.py
+++ b/mne_nirs/experimental_design/_experimental_design.py
@@ -122,7 +122,7 @@ def create_boxcar(raw, event_id=None, stim_dur=1):
     s : array
         Returns an array for each annotation label.
     """
-    bc = np.ones(round(raw.info['sfreq'] * stim_dur))
+    bc = np.ones(int(round(raw.info['sfreq'] * stim_dur)))
     events, ids = mne.events_from_annotations(raw, event_id=event_id)
     s = np.zeros((len(raw.times), len(ids)))
     for idx, id in enumerate(ids):

--- a/mne_nirs/io/fold/tests/test_fold.py
+++ b/mne_nirs/io/fold/tests/test_fold.py
@@ -16,7 +16,6 @@ from mne.channels import make_standard_montage
 from mne.channels.montage import transform_to_head
 from mne.datasets.testing import data_path, requires_testing_data
 from mne.io import read_raw_nirx, read_fiducials
-from mne.utils import check_version
 
 from mne_nirs.io.fold._fold import _generate_montage_locations,\
     _find_closest_standard_location, _read_fold_xls

--- a/mne_nirs/io/fold/tests/test_fold.py
+++ b/mne_nirs/io/fold/tests/test_fold.py
@@ -30,11 +30,9 @@ foldfile = thisfile / "data" / "example.xls"
 fname_nirx_15_3_short = Path(data_path(download=False)) / \
     'NIRx' / 'nirscout' / 'nirx_15_3_recording'
 
-requires_xlrd = pytest.mark.skipif(
-    not check_version('xlrd', '1.0'), reason='Requires xlrd >= 1.0')
+pytest.importorskip('xlrd', '1.0')
 
 
-@requires_xlrd
 @pytest.mark.parametrize('fold_files', (str, None, list))
 def test_channel_specificity(monkeypatch, tmp_path, fold_files):
     raw = read_raw_nirx(fname_nirx_15_3_short, preload=True)
@@ -97,7 +95,6 @@ def test_channel_specificity(monkeypatch, tmp_path, fold_files):
     assert (res_1['Specificity'] == res_2['Specificity']).all()
 
 
-@requires_xlrd
 def test_landmark_specificity():
     raw = read_raw_nirx(fname_nirx_15_3_short, preload=True)
     with pytest.warns(RuntimeWarning, match='No fOLD table entry'):
@@ -108,7 +105,6 @@ def test_landmark_specificity():
     assert np.min(res) >= 0
 
 
-@requires_xlrd
 def test_fold_workflow():
     # Read raw data
     raw = read_raw_nirx(fname_nirx_15_3_short, preload=True)
@@ -136,7 +132,6 @@ def test_fold_workflow():
     assert specificity.values == 12.34
 
 
-@requires_xlrd
 def test_fold_reader():
     tbl = _read_fold_xls(foldfile, atlas="Juelich")
     assert isinstance(tbl, pd.DataFrame)

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -11,7 +11,7 @@ import pandas as pd
 from snirf import validateSnirf, Snirf
 
 from mne.datasets.testing import data_path, requires_testing_data
-from mne.utils import requires_h5py, object_diff
+from mne.utils import object_diff
 from mne.io import read_raw_snirf, read_raw_nirx
 from mne.preprocessing.nirs import optical_density, beer_lambert_law
 from mne_nirs.io.snirf import write_raw_snirf, SPEC_FORMAT_VERSION, \
@@ -29,13 +29,9 @@ fname_nirx_15_2_short = op.join(data_path(download=False),
                                 'nirx_15_2_recording_w_short')
 fname_snirf_aux = aux.data_path()
 
-pytest.importorskip('mne', '1.0')  # these tests are broken on 0.24!
-
-requires_mne_1_4 = pytest.mark.skipif(not check_version('mne', '1.4'),
-                                      reason='Needs MNE-Python 1.4')
+pytest.importorskip('h5py')
 
 
-@requires_h5py
 @requires_testing_data
 @pytest.mark.parametrize('fname', (
     fname_nirx_15_2_short,
@@ -85,7 +81,6 @@ def test_snirf_write_raw(fname, tmpdir):
     _verify_snirf_version_str(test_file)
 
 
-@requires_h5py
 @requires_testing_data
 @pytest.mark.parametrize('fname', (
     fname_nirx_15_2_short,
@@ -107,7 +102,6 @@ def test_snirf_write_optical_density(fname, tmpdir):
     assert result.is_valid()
 
 
-@requires_h5py
 @requires_testing_data
 @pytest.mark.parametrize('fname', (
     fname_nirx_15_2,
@@ -148,7 +142,6 @@ def test_snirf_write_haemoglobin(fname, tmpdir):
     assert result.is_valid()
 
 
-@requires_h5py
 @requires_testing_data
 @pytest.mark.parametrize('fname', (
     fname_nirx_15_2,
@@ -163,7 +156,6 @@ def test_snirf_nobday(fname, tmpdir):
     assert_allclose(raw.get_data(), raw_orig.get_data())
 
 
-@requires_h5py
 @requires_testing_data
 @pytest.mark.parametrize('fname', (
     fname_nirx_15_2,
@@ -257,7 +249,6 @@ def test_aux_read():
     assert len(a['gyroscope_1_z']) == len(raw.times)
 
 
-@requires_h5py
 @requires_testing_data
 @pytest.mark.parametrize('fname', (
     fname_nirx_15_2,
@@ -279,8 +270,6 @@ def test_snirf_stim_roundtrip(fname, tmpdir):
                        raw.annotations.description)
 
 
-@requires_mne_1_4
-@requires_h5py
 @requires_testing_data
 @pytest.mark.parametrize('fname', (
     fname_nirx_15_2,
@@ -291,6 +280,7 @@ def test_snirf_stim_roundtrip(fname, tmpdir):
 ))
 def test_snirf_duration(fname, newduration, tmpdir):
     """Ensure snirf annotations are written to file."""
+    pytest.importorskip('mne', '1.4')
     raw_orig = read_raw_nirx(fname, preload=True)
     assert raw_orig.annotations.duration[0] == 1
     raw_mod = raw_orig.copy()
@@ -302,7 +292,6 @@ def test_snirf_duration(fname, newduration, tmpdir):
     assert raw.annotations.duration[-1] == newduration
 
 
-@requires_h5py
 @requires_testing_data
 @pytest.mark.parametrize('fname', (
     fname_nirx_15_2,
@@ -328,7 +317,6 @@ def test_optical_density_roundtrip(fname, tmpdir):
                        od.info.get_channel_types())
 
 
-@requires_h5py
 @requires_testing_data
 @pytest.mark.parametrize('fname', (
     fname_nirx_15_2,

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -17,8 +17,6 @@ from mne.preprocessing.nirs import optical_density, beer_lambert_law
 from mne_nirs.io.snirf import write_raw_snirf, SPEC_FORMAT_VERSION, \
     read_snirf_aux_data
 import mne_nirs.datasets.snirf_with_aux as aux
-from mne.utils import check_version
-
 
 fname_nirx_15_0 = op.join(data_path(download=False),
                           'NIRx', 'nirscout', 'nirx_15_0_recording')

--- a/mne_nirs/preprocessing/tests/test_mayer.py
+++ b/mne_nirs/preprocessing/tests/test_mayer.py
@@ -5,17 +5,13 @@
 import os
 import mne
 import pytest
-from functools import partial
 import numpy as np
 
-from mne.utils._testing import requires_module
 from mne_nirs.preprocessing import quantify_mayer_fooof
 
+pytest.importorskip('fooof')
 
-requires_fooof = partial(requires_module, name='fooof')
 
-
-@requires_fooof
 def test_mayer():
     fnirs_data_folder = mne.datasets.fnirs_motor.data_path()
     fnirs_raw_dir = os.path.join(fnirs_data_folder, 'Participant-1')

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -26,9 +26,6 @@ testing_path = testing.data_path(download=False)
 raw_path = str(testing_path) + '/NIRx/nirscout/nirx_15_2_recording_w_short'
 subjects_dir = str(testing_path) + '/subjects'
 
-requires_mne_1 = pytest.mark.skipif(not check_version('mne', '1.0'),
-                                    reason='Needs MNE-Python 1.0')
-
 
 def test_plot_nirs_source_detector_pyvista(requires_pyvista):
     raw = mne.io.read_raw_nirx(raw_path)
@@ -127,7 +124,6 @@ def test_fig_from_axes():
 
 
 # surface arg
-@requires_mne_1
 def test_run_plot_GLM_projection(requires_pyvista):
     raw_intensity = _load_dataset()
     raw_intensity.crop(450, 600)  # Keep the test fast
@@ -154,16 +150,12 @@ def test_run_plot_GLM_projection(requires_pyvista):
         assert type(brain) == mne.viz._brain.Brain
 
 
-@requires_mne_1
 @pytest.mark.parametrize('fname_raw, to_1020, ch_names', [
     (raw_path, False, None),
     (raw_path, True, 'numbered'),
     (raw_path, True, defaultdict(lambda: '')),
 ])
 def test_plot_3d_montage(requires_pyvista, fname_raw, to_1020, ch_names):
-    import pyvista
-    pyvista.close_all()
-    assert len(pyvista.plotting._ALL_PLOTTERS) == 0
     raw = mne.io.read_raw_nirx(fname_raw)
     if to_1020:
         need = set(sum(

--- a/mne_nirs/visualisation/tests/test_visualisation.py
+++ b/mne_nirs/visualisation/tests/test_visualisation.py
@@ -176,7 +176,6 @@ def test_plot_3d_montage(requires_pyvista, fname_raw, to_1020, ch_names):
         mne_nirs.viz.plot_3d_montage(
             raw.info, view_map, subject='sample', surface='white',
             subjects_dir=subjects_dir, ch_names=ch_names, verbose=True)
-    assert len(pyvista.plotting._ALL_PLOTTERS) == 0
     log = log.getvalue().lower()
     if to_1020:
         assert 'automatically mapped' in log

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ DOWNLOAD_URL = 'https://github.com/mne-tools/mne-nirs'
 VERSION = __version__
 INSTALL_REQUIRES = ['numpy>=1.11.3',
                     'scipy>=0.17.1',
-                    'mne>=0.24.0',
+                    'mne>=1.0',
                     'h5io>=0.1.7',
                     'nilearn>=0.9'],
 CLASSIFIERS = ['Intended Audience :: Science/Research',


### PR DESCRIPTION
We deprecated `requires_module` in MNE-Python, this cleans up some stuff with `importorskip`