### PR TITLE
fix: change ci param to errorbar in sns-catplot

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,6 +17,7 @@ To install a specific version of the library you would run ``pip install mne-nir
 v0.6.dev0
 ---------
 
+* Changed ci param to errorbar in sns-catplot functions. By `Nicolas Busato`_.
 * Fix bug in SNIRF writer that caused incorrect duration to be written to file. By `Robert Luke`_.
 * Add option to export montage location in SNIRF using the landmarkLabels field. By `Robert Luke`_.
 * Fix continuous integration issues and update test infrastructure. By `Florin Pop`_.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -197,3 +197,4 @@ Enhancements
 .. _Samuel Powell: https://github.com/samuelpowell
 .. _Johann Benerradi: https://github.com/HanBnrd
 .. _Florin Pop: https://github.com/florin-pop
+.. _Nicolas Busato: https://github.com/Busato

--- a/examples/general/plot_12_group_glm.py
+++ b/examples/general/plot_12_group_glm.py
@@ -278,7 +278,7 @@ for sub in subjects:  # Loop from first to fifth subject
 grp_results = df_roi.query("Condition in ['Control', 'Tapping_Left', 'Tapping_Right']")
 grp_results = grp_results.query("Chroma in ['hbo']")
 
-sns.catplot(x="Condition", y="theta", col="ID", hue="ROI", data=grp_results, col_wrap=5, ci=None, palette="muted", height=4, s=10)
+sns.catplot(x="Condition", y="theta", col="ID", hue="ROI", data=grp_results, col_wrap=5, errorbar=None, palette="muted", height=4, s=10)
 
 
 # %%
@@ -372,7 +372,7 @@ roi_model = smf.mixedlm("theta ~ -1 + ROI:Condition:Chroma",
 
 df = statsmodels_to_results(roi_model)
 
-sns.catplot(x="Condition", y="Coef.", hue="ROI", data=df.query("Chroma == 'hbo'"), ci=None, palette="muted", height=4, s=10)
+sns.catplot(x="Condition", y="Coef.", hue="ROI", data=df.query("Chroma == 'hbo'"), errorbar=None, palette="muted", height=4, s=10)
 
 
 # %%

--- a/examples/general/plot_16_waveform_group.py
+++ b/examples/general/plot_16_waveform_group.py
@@ -349,7 +349,7 @@ df.head()
 # For this reason, fNIRS is most appropriate for detecting changes within a
 # single ROI between conditions.
 
-sns.catplot(x="Condition", y="Value", hue="ID", data=df.query("Chroma == 'hbo'"), ci=None, palette="muted", height=4, s=10)
+sns.catplot(x="Condition", y="Value", hue="ID", data=df.query("Chroma == 'hbo'"), errorbar=None, palette="muted", height=4, s=10)
 
 
 # %%

--- a/mne_nirs/tests/test_examples.py
+++ b/mne_nirs/tests/test_examples.py
@@ -46,7 +46,6 @@ requires_mne_bids_nirs = pytest.mark.skipif(
 @pytest.mark.filterwarnings('ignore:No bad channels to interpolate.*:')
 @pytest.mark.filterwarnings('ignore:divide by zero encountered.*:')
 @pytest.mark.filterwarnings('ignore:invalid value encountered.*:')
-@pytest.mark.filterwarnings("ignore:.*\n\nThe `ci` parameter is deprecated.*:")
 @pytest.mark.skipif(
     sys.platform.startswith('win'), reason='Unstable on Windows')
 @pytest.mark.examples


### PR DESCRIPTION
#### What does this implement/fix?
Two tests were failing because of a deprecation of the `ci` parameter in `sns.catplot` [function](https://seaborn.pydata.org/generated/seaborn.catplot.html).

![image](https://github.com/mne-tools/mne-nirs/assets/11623010/29885fd3-409f-4512-85c6-d26dec57f9b3)

They were changed to `errorbar` instead that do the same thing when using None (both of the were using it)


Contributed with ❤️ by AE Studio