### PR TITLE
MAINT: Fix CIs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ MNE-NIRS and MNE-Python provide a wide variety of tools to use when processing f
 * Visualisation tools for all stages of processing from raw data to processed waveforms, GLM result visualisation, including both sensor and cortical surface projections.
 * Data cleaning functions including popular short channel techniques and negative correlation enhancement.
 * Group level analysis using `(robust) linear mixed effects models <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_12_group_glm.html>`_ and `waveform averaging <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_16_waveform_group.html>`_.
-* And much more! Check out the documentation `examples <https://mne.tools/mne-nirs/stable/auto_examples/index.html>`_ and the API `for more details <https://mne.tools/mne-nirs/stable/api.html>`_.
+* And much more! Check out the documentation `examples <https://mne.tools/mne-nirs/stable/auto_examples/index.html>`__ and the API `for more details <https://mne.tools/mne-nirs/stable/api.html>`_.
 
 .. features-end
 

--- a/README.rst
+++ b/README.rst
@@ -35,18 +35,21 @@ You can find a list of  `examples within the documentation <https://mne.tools/mn
 Features
 --------
 
+.. features-start
+
 MNE-NIRS and MNE-Python provide a wide variety of tools to use when processing fNIRS data including:
 
 * Loading data from a `wide variety of devices <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_01_data_io.html>`_, including `SNIRF files <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_19_snirf.html>`_.
 * `Apply 3D sensor locations <https://mne.tools/stable/overview/implementation.html#supported-formats-for-digitized-3d-locations>`_ from common digitisation systems such as Polhemus.
 * Standard preprocessing including `optical density calculation and Beer-Lambert Law conversion <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_15_waveform.html#id2>`_, filtering, etc.
 * Data quality metrics including `scalp coupling index <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_15_waveform.html#id3>`_ and `peak power <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_22_quality.html#peak-power>`_.
-* GLM analysis with a wide variety of cusomisation including `including FIR <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_13_fir_glm.html>`_ or `canonical HRF <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_11_hrf_measured.html>`_ analysis, higher order `autoregressive noise models <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_10_hrf_simulation.html#using-autoregressive-models-in-the-glm-to-account-for-noise-structure>`_, `short channel regression, region of interest analysis <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_11_hrf_measured.html>`_, etc.
+* GLM analysis with a wide variety of customisation including `including FIR <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_13_fir_glm.html>`_ or `canonical HRF <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_11_hrf_measured.html>`_ analysis, higher order `autoregressive noise models <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_10_hrf_simulation.html#using-autoregressive-models-in-the-glm-to-account-for-noise-structure>`_, `short channel regression, region of interest analysis <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_11_hrf_measured.html>`_, etc.
 * Visualisation tools for all stages of processing from raw data to processed waveforms, GLM result visualisation, including both sensor and cortical surface projections.
 * Data cleaning functions including popular short channel techniques and negative correlation enhancement.
 * Group level analysis using `(robust) linear mixed effects models <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_12_group_glm.html>`_ and `waveform averaging <https://mne.tools/mne-nirs/stable/auto_examples/general/plot_16_waveform_group.html>`_.
 * And much more! Check out the documentation `examples <https://mne.tools/mne-nirs/stable/auto_examples/index.html>`_ and the API `for more details <https://mne.tools/mne-nirs/stable/api.html>`_.
 
+.. features-end
 
 Contributing
 ------------

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+comment: false
+github_checks:  # too noisy, even though "a" interactively disables them
+  annotations: false
+
+codecov:
+  notify:
+    require_ci_to_pass: false
+
+coverage:
+  status:
+    patch:
+      default:
+        informational: true
+        target: 95%
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
+    project:
+      default: false
+      library:
+        informational: true
+        target: 90%
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,22 +9,12 @@ Usage
 
 See the `examples <auto_examples/index.html>`_ and `API documentation <api.html>`_.
 
-
 Features
 --------
 
-MNE-NIRS and MNE-Python provide a wide variety of tools to use when processing NIRS data including:
-
-* Loading data from a wide variety of devices, including SNIRF files.
-* Apply 3D sensor locations from common digitisation systems such as Polhemus.
-* Standard preprocessing including optical density calculation and Beer-Lambert Law conversion, filtering, etc.
-* Data quality metrics including scalp coupling index and peak power.
-* GLM analysis with a wide variety of cusomisation including including FIR or canonical HRF analysis, higher order autoregressive noise models, short channel regression, region of interest analysis, etc.
-* Visualisation tools for all stages of processing from raw data to processed waveforms, GLM result visualisation, including both sensor and cortical surface projections.
-* Data cleaning functions including popular short channel techniques and negative correlation enhancement.
-* Group level analysis using (robust) linear mixed effects models and waveform averaging.
-* And much more! Check out the documentation examples and the API for more details.
-
+.. include:: ../README.rst
+   :start-after: .. features-start
+   :end-before: .. features-end
 
 Installation
 ------------
@@ -32,46 +22,6 @@ Installation
 Before installing MNE-NIRS you must install Python and MNE-Python.
 To install Python and MNE-Python follow `these instructions <https://mne.tools/stable/install/index.html>`_.
 We recommend using the standalone installer option unless you are a python expert.
-
-
-Install via Standalone Installer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-1. Download the installer from `the MNE-Python website <https://mne.tools/stable/install/index.html>`_.
-2. Run the installer and wait for it to complete.
-3. Once the installer is complete you will have an MNE-Python directory in your Applications folder.
-4. Double click on the `Prompt (MNE)`
-5. Once the prompt has loaded, run `jupyter lab` and it will open Jupyter in your web browser.
-6. Now try one of the MNE-NIRS example notebooks by clicking `Download Jupyter notebook` at the bottom of any example.
-7. Use the file browser in the jupyter lab web interface (top left of page) to browse to where you downloaded the example to. Double click to open it.
-
-If you need the latest version of MNE-Python or MNE-NIRS you can enter the following at the prompt:
-
-.. code:: console
-
-   $ pip install -U --no-deps git+https://github.com/mne-tools/mne-python.git@main
-   $ pip install -U --no-deps git+https://github.com/mne-tools/mne-nirs.git@main
-
-
-Install via Conda or Pip
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-You must use MNE-Python v1.0 or above.
-Follow the installation instructions on the
-`MNE-Python documentation site <https://mne.tools/dev/install/manual_install.html>`_.
-
-Then run the following code to install MNE-NIRS:
-
-.. code:: console
-
-    $ pip install mne-nirs
-
-
-Or if you wish to run the latest development version of MNE-NIRS:
-
-.. code:: console
-
-    $ pip install git+https://github.com/mne-tools/mne-nirs.git@main
 
 
 Upgrading your software version

--- a/examples/general/plot_15_waveform.py
+++ b/examples/general/plot_15_waveform.py
@@ -162,12 +162,10 @@ raw_haemo.plot(n_channels=len(raw_haemo.ch_names),
 
 fig = raw_haemo.plot_psd(average=True)
 fig.suptitle('Before filtering', weight='bold', size='x-large')
-fig.subplots_adjust(top=0.88)
 raw_haemo = raw_haemo.filter(0.05, 0.7, h_trans_bandwidth=0.2,
                              l_trans_bandwidth=0.02)
 fig = raw_haemo.plot_psd(average=True)
 fig.suptitle('After filtering', weight='bold', size='x-large')
-fig.subplots_adjust(top=0.88)
 
 # %%
 # Extract epochs
@@ -183,7 +181,6 @@ fig.subplots_adjust(top=0.88)
 events, event_dict = mne.events_from_annotations(raw_haemo)
 fig = mne.viz.plot_events(events, event_id=event_dict,
                           sfreq=raw_haemo.info['sfreq'])
-fig.subplots_adjust(right=0.7)  # make room for the legend
 
 
 # %%

--- a/examples/general/plot_15_waveform.py
+++ b/examples/general/plot_15_waveform.py
@@ -330,7 +330,6 @@ for column, condition in enumerate(
         ['Tapping Left', 'Tapping Right', 'Left-Right']):
     for row, chroma in enumerate(['HbO', 'HbR']):
         axes[row, column].set_title('{}: {}'.format(chroma, condition))
-fig.tight_layout()
 
 # %%
 # Lastly, we can also look at the individual waveforms to see what is

--- a/examples/general/plot_99_bad.py
+++ b/examples/general/plot_99_bad.py
@@ -122,12 +122,10 @@ raw_haemo._data[::2, :]= np.random.randn(20, 23239) / 1.0e6 * 3
 
 fig = raw_haemo.plot_psd(average=True)
 fig.suptitle('Before filtering', weight='bold', size='x-large')
-fig.subplots_adjust(top=0.88)
 raw_haemo = raw_haemo.filter(0.05, 0.1, h_trans_bandwidth=0.2,
                              l_trans_bandwidth=0.02)
 fig = raw_haemo.plot_psd(average=True)
 fig.suptitle('After filtering', weight='bold', size='x-large')
-fig.subplots_adjust(top=0.88)
 
 
 # %%
@@ -156,7 +154,6 @@ events, _ = mne.events_from_annotations(raw_haemo, event_id={'1.0': 1,
 event_dict = {'Control': 1, 'Tapping/Left': 2, 'Tapping/Right': 3}
 fig = mne.viz.plot_events(events, event_id=event_dict,
                           sfreq=raw_haemo.info['sfreq'])
-fig.subplots_adjust(right=0.7)  # make room for the legend
 
 
 # %%

--- a/mne_nirs/conftest.py
+++ b/mne_nirs/conftest.py
@@ -53,7 +53,6 @@ def pytest_configure(config):
     # seaborn
     ignore:is_categorical_dtype is deprecated.*:FutureWarning
     ignore:use_inf_as_na option is deprecated.*:FutureWarning
-    ignore:The `ci` parameter is deprecated.*:FutureWarning
     # nilearn
     ignore:The provided callable <function sum.*:FutureWarning
     # TODO: in an example (should fix eventually)

--- a/mne_nirs/conftest.py
+++ b/mne_nirs/conftest.py
@@ -53,6 +53,7 @@ def pytest_configure(config):
     # seaborn
     ignore:is_categorical_dtype is deprecated.*:FutureWarning
     ignore:use_inf_as_na option is deprecated.*:FutureWarning
+    ignore:The `ci` parameter is deprecated.*:FutureWarning
     # nilearn
     ignore:The provided callable <function sum.*:FutureWarning
     # TODO: in an example (should fix eventually)

--- a/mne_nirs/tests/test_examples.py
+++ b/mne_nirs/tests/test_examples.py
@@ -46,6 +46,7 @@ requires_mne_bids_nirs = pytest.mark.skipif(
 @pytest.mark.filterwarnings('ignore:No bad channels to interpolate.*:')
 @pytest.mark.filterwarnings('ignore:divide by zero encountered.*:')
 @pytest.mark.filterwarnings('ignore:invalid value encountered.*:')
+@pytest.mark.filterwarnings("ignore:\n\nThe `ci` parameter is deprecated.*:")
 @pytest.mark.skipif(
     sys.platform.startswith('win'), reason='Unstable on Windows')
 @pytest.mark.examples

--- a/mne_nirs/tests/test_examples.py
+++ b/mne_nirs/tests/test_examples.py
@@ -46,7 +46,7 @@ requires_mne_bids_nirs = pytest.mark.skipif(
 @pytest.mark.filterwarnings('ignore:No bad channels to interpolate.*:')
 @pytest.mark.filterwarnings('ignore:divide by zero encountered.*:')
 @pytest.mark.filterwarnings('ignore:invalid value encountered.*:')
-@pytest.mark.filterwarnings("ignore:\n\nThe `ci` parameter is deprecated.*:")
+@pytest.mark.filterwarnings("ignore:.*\n\nThe `ci` parameter is deprecated.*:")
 @pytest.mark.skipif(
     sys.platform.startswith('win'), reason='Unstable on Windows')
 @pytest.mark.examples

--- a/mne_nirs/visualisation/_plot_quality_metrics.py
+++ b/mne_nirs/visualisation/_plot_quality_metrics.py
@@ -48,7 +48,7 @@ def plot_timechannel_quality_metric(raw, scores, times, threshold=0.1,
     vsize = 0.2 * n_chans
 
     # First, plot the "raw" scores.
-    fig, ax = plt.subplots(1, 2, figsize=(20, vsize))
+    fig, ax = plt.subplots(1, 2, figsize=(20, vsize), layout='constrained')
     fig.suptitle(title, fontsize=16, fontweight='bold')
     sns.heatmap(data=data_to_plot, cmap='Reds_r', vmin=0, vmax=1,
                 cbar_kws=dict(label='Score'), ax=ax[0])
@@ -69,9 +69,6 @@ def plot_timechannel_quality_metric(raw, scores, times, threshold=0.1,
         for x in range(1, len(times))]
     ax[1].set_title('Scores < Limit', fontweight='bold')
     markbad(raw, ax[1])
-
-    # The figure title should not overlap with the subplots.
-    fig.tight_layout(rect=[0, 0.03, 1, 0.95])
 
     return fig
 


### PR DESCRIPTION
1. Use `.. include` to deduplicate `index.rst` and `README.rst`
2. Fix spelling error
3. Remove `tight_layout` that is no longer needed (and emits a warning)