### PR TITLE
write subject ID to ["his_id"], not ["first_name"]

### DIFF
--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -98,7 +98,12 @@ def _add_metadata_tags(raw, nirs):
     metadata_tags.create_dataset("MeasurementTime", data=_str_encode(timestr))
 
     # Store demographic info
-    subject_id = raw.info["subject_info"]["his_id"]
+    subject_id = "_".join(
+        raw.info["subject_info"][key]
+        for key in ["first_name", "middle_name", "last_name"]
+        if key in raw.info["subject_info"]
+    )
+    subject_id = raw.info["subject_info"].get("his_id", subject_id)
     metadata_tags.create_dataset("SubjectID", data=_str_encode(subject_id))
 
     # Store the units of measurement

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -98,7 +98,7 @@ def _add_metadata_tags(raw, nirs):
     metadata_tags.create_dataset("MeasurementTime", data=_str_encode(timestr))
 
     # Store demographic info
-    subject_id = raw.info["subject_info"]["first_name"]
+    subject_id = raw.info["subject_info"]["his_id"]
     metadata_tags.create_dataset("SubjectID", data=_str_encode(subject_id))
 
     # Store the units of measurement

--- a/mne_nirs/io/snirf/_snirf.py
+++ b/mne_nirs/io/snirf/_snirf.py
@@ -111,12 +111,10 @@ def _add_metadata_tags(raw, nirs):
         birthday = datetime.date(*raw.info["subject_info"]["birthday"])
         birthstr = birthday.strftime("%Y-%m-%d")
         metadata_tags.create_dataset("DateOfBirth", data=[_str_encode(birthstr)])
-    if "middle_name" in raw.info["subject_info"]:
-        middle_name = raw.info["subject_info"]["middle_name"]
-        metadata_tags.create_dataset("middleName", data=[_str_encode(middle_name)])
-    if "last_name" in raw.info["subject_info"]:
-        last_name = raw.info["subject_info"]["last_name"]
-        metadata_tags.create_dataset("lastName", data=[_str_encode(last_name)])
+    for key in ("first", "middle", "last"):
+        name = raw.info["subject_info"].get(f"{key}_name", None)
+        if name is not None:
+            metadata_tags.create_dataset(f"{key}Name", data=[_str_encode(name)])
     if "sex" in raw.info["subject_info"]:
         sex = str(int(raw.info["subject_info"]["sex"]))
         metadata_tags.create_dataset("sex", data=[_str_encode(sex)])

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -53,7 +53,6 @@ def test_snirf_write_raw(fname, tmpdir):
     # Correct MNE bug with reading
     subj_info = raw.info["subject_info"]
     if not MNE_1_7:
-        assert "_" in subj_info["first_name"]
         subj_info["first_name"] = subj_info["first_name"].split("_")[0]
         assert "his_id" not in subj_info
         subj_info["his_id"] = his_id

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -30,6 +30,8 @@ fname_snirf_aux = aux.data_path()
 
 pytest.importorskip("h5py")
 
+MNE_1_7 = check_version("mne", "1.7")
+
 
 @requires_testing_data
 @pytest.mark.parametrize(
@@ -50,7 +52,7 @@ def test_snirf_write_raw(fname, tmpdir):
     raw = read_raw_snirf(test_file, preload=True)
     # Correct MNE bug with reading
     subj_info = raw.info["subject_info"]
-    if not check_version("mne", "1.7"):
+    if not MNE_1_7:
         assert "_" in subj_info["first_name"]
         subj_info["first_name"] = subj_info["first_name"].split("_")[0]
         assert "his_id" not in subj_info
@@ -100,7 +102,10 @@ def test_snirf_write_raw(fname, tmpdir):
     del raw.info["subject_info"]["his_id"]
     write_raw_snirf(raw, test_file)
     raw = read_raw_snirf(test_file)
-    assert raw.info["subject_info"]["his_id"] == his_id
+    if MNE_1_7:
+        assert raw.info["subject_info"]["his_id"] == his_id
+    else:
+        assert raw.info["subject_info"]["first_name"] == his_id
 
 
 @requires_testing_data

--- a/mne_nirs/io/snirf/tests/test_snirf.py
+++ b/mne_nirs/io/snirf/tests/test_snirf.py
@@ -47,7 +47,7 @@ def test_snirf_write_raw(fname, tmpdir):
     assert raw_orig.info["subject_info"]["his_id"] == his_id
     test_file = tmpdir.join("test_raw.snirf")
     write_raw_snirf(raw_orig, test_file)
-    raw = read_raw_snirf(test_file)
+    raw = read_raw_snirf(test_file, preload=True)
     # Correct MNE bug with reading
     subj_info = raw.info["subject_info"]
     if not check_version("mne", "1.7"):
@@ -95,6 +95,12 @@ def test_snirf_write_raw(fname, tmpdir):
 
     _verify_snirf_required_fields(test_file)
     _verify_snirf_version_str(test_file)
+
+    # make sure one can be written and read with no his_id (e.g., old MNE-Python)
+    del raw.info["subject_info"]["his_id"]
+    write_raw_snirf(raw, test_file)
+    raw = read_raw_snirf(test_file)
+    assert raw.info["subject_info"]["his_id"] == his_id
 
 
 @requires_testing_data


### PR DESCRIPTION
#### Reference issue
Fixes #544 


#### What does this implement/fix?
write subject ID to ["subject_info"]["his_id"], not ["subject_info"]["first_name"]. This makes the code more consistent with BIDS specifications, and fixes error generated by `write_raw_snirf()` described in #544 


