### PR TITLE
BUG: Fix bug with entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ classifiers = [
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
 ]
-scripts = { mne = "mne.commands.utils:main" }
 dependencies = [
     "numpy>=1.11.3,<3",
     "scipy>=0.17.1",


### PR DESCRIPTION
This errant addition breaks the `mne` command line tool, see https://github.com/mne-tools/mne-installers/pull/287. Let's get rid of it.

