### PR TITLE
FIX: Auxiliary data from snirf

### DIFF
--- a/mne_nirs/io/snirf/_aux.py
+++ b/mne_nirs/io/snirf/_aux.py
@@ -50,7 +50,7 @@ def read_snirf_aux_data(fname: str, raw: Raw):
             aux_data_interp = interpolate.interp1d(
                 aux_time, aux_data, axis=0, bounds_error=False, fill_value="extrapolate"
             )
-            aux_data_matched_to_raw = aux_data_interp(raw.times)
+            aux_data_matched_to_raw = aux_data_interp(raw.times).flatten()
             d[aux_names[idx]] = aux_data_matched_to_raw
 
         df = DataFrame(data=d)
@@ -60,4 +60,4 @@ def read_snirf_aux_data(fname: str, raw: Raw):
 
 
 def _decode_name(key):
-    return np.array(key)[0].decode()
+    return np.array(key).item().decode()


### PR DESCRIPTION
Fixes mne-tools/mne-nirs#630

The AUX channels in the .snirf files saved with some versions of Aurora (NIRx) have an incorrect shape.  Because of that, `mne_nirs.io.snirf.read_snirf_aux_data` raises an exception.

We add more resilience to the array shapes (1d or 2d), to manage how the .snirf (hdf5) file stores the AUX data when generated by different vendors/versions.