### PR TITLE
ENH/FIX: Multi-wavelength support for scalp_coupling_index_windowed, peak_power, and plot_3d_montage

### DIFF
--- a/mne_nirs/preprocessing/_peak_power.py
+++ b/mne_nirs/preprocessing/_peak_power.py
@@ -56,7 +56,7 @@ def peak_power(
 
     Notes
     -----
-    This implementation of peak power differs from Pollonini's original[1]_[2]_,
+    This implementation of peak power differs from Pollonini's original [1]_ [2]_,
     in that the original calculates peak power on raw data, whereas multiple
     types are allowed here; and while both implementations calculate a kind of
     cosine similarity, the mathematical details are different. Users are

--- a/mne_nirs/preprocessing/_peak_power.py
+++ b/mne_nirs/preprocessing/_peak_power.py
@@ -54,13 +54,13 @@ def peak_power(
         List of the start and end times of each window used to compute the
         peak spectral power.
 
-    Warning
-    -------
-    This implementation of peak power differs from Pollonini's original in that
-    the original calculates peak power on raw data, whereas multiple types are
-    allowed here; and while both implementations calculate a kind of cosine
-    similarity, the mathematical details are different. Users are advised to
-    check the results and adjust parameters as needed.
+    Notes
+    -----
+    This implementation of peak power differs from Pollonini's original[1]_[2]_,
+    in that the original calculates peak power on raw data, whereas multiple
+    types are allowed here; and while both implementations calculate a kind of
+    cosine similarity, the mathematical details are different. Users are
+    advised to check the results and adjust parameters as needed.
 
     References
     ----------

--- a/mne_nirs/preprocessing/_peak_power.py
+++ b/mne_nirs/preprocessing/_peak_power.py
@@ -5,7 +5,7 @@
 import numpy as np
 from mne.filter import filter_data
 from mne.io import BaseRaw
-from mne.preprocessing.nirs import _validate_nirs_info
+from mne.preprocessing.nirs import _channel_frequencies, _validate_nirs_info
 from mne.utils import _validate_type, verbose
 from scipy.signal import periodogram
 
@@ -54,6 +54,14 @@ def peak_power(
         List of the start and end times of each window used to compute the
         peak spectral power.
 
+    Warning
+    -------
+    This implementation of peak power differs from Pollonini's original in that
+    the original calculates peak power on raw data, whereas multiple types are
+    allowed here; and while both implementations calculate a kind of cosine
+    similarity, the mathematical details are different. Users are advised to
+    check the results and adjust parameters as needed.
+
     References
     ----------
     .. [1] Pollonini L et al., “PHOEBE: a method for real time mapping of
@@ -63,11 +71,24 @@ def peak_power(
            quality assessment of fNIRS scans." Optics and the Brain.
            Optical Society of America, 2020.
     """
+    # Copy raw to avoid modifying original and load data into memory
     raw = raw.copy().load_data()
+
+    # Validate that the input contains raw fNIRS data
+    # Note that peak_power currently does not require a specific data type (e.g. OD)
     _validate_type(raw, BaseRaw, "raw")
 
+    # `picks` returns a list of channels ordered alphanumerically and grouped by
+    # channel groups (i.e. same source-detector pair). The order of channels in
+    # `picks` can be differ from the order of channels in `raw`.
     picks = _validate_nirs_info(raw.info)
 
+    # Number of wavelengths extracted from channel names
+    n_wavelengths = len(np.unique(_channel_frequencies(raw.info)))
+
+    # Bandpass filter data to extract heartbeat-related frequencies
+    # Note: filtering is applied only to the selected channels (picks),
+    # with channel order preserved, regardless of how the picks are ordered.
     filtered_data = filter_data(
         raw._data,
         raw.info["sfreq"],
@@ -79,42 +100,49 @@ def peak_power(
         h_trans_bandwidth=h_trans_bandwidth,
     )
 
-    window_samples = int(np.ceil(time_window * raw.info["sfreq"]))
-    n_windows = int(np.floor(len(raw) / window_samples))
+    samples_per_window = int(np.ceil(time_window * raw.info["sfreq"]))
+    n_windows = int(np.floor(len(raw) / samples_per_window))
 
     scores = np.zeros((len(picks), n_windows))
     times = []
 
     for window in range(n_windows):
-        start_sample = int(window * window_samples)
-        end_sample = start_sample + window_samples
-        end_sample = np.min([end_sample, len(raw) - 1])
+        start_sample = int(window * samples_per_window)
+        end_sample = min(start_sample + samples_per_window, len(raw) - 1)
 
         t_start = raw.times[start_sample]
         t_stop = raw.times[end_sample]
         times.append((t_start, t_stop))
 
-        for ii in range(0, len(picks), 2):
-            c1 = filtered_data[picks[ii]][start_sample:end_sample]
-            c2 = filtered_data[picks[ii + 1]][start_sample:end_sample]
+        # pair indices for all channels pairs
+        pair_indices = np.triu_indices(n_wavelengths, k=1)
 
-            # protect against zero
-            c1 = c1 / (np.std(c1) or 1)
-            c2 = c2 / (np.std(c2) or 1)
+        for gg in range(0, len(picks), n_wavelengths):
+            ch_group = picks[gg : gg + n_wavelengths]
+            group_data = filtered_data[ch_group, start_sample:end_sample]
 
-            c = np.correlate(c1, c2, "full")
-            c = c / (window_samples)
-            [f, pxx] = periodogram(c, fs=raw.info["sfreq"], window="hamming")
+            # Calculate pairwise peak power within group
+            group_data = np.array([ch / (np.std(ch) or 1) for ch in group_data])
+            peak_powers = []
+            for ii, jj in zip(*pair_indices):
+                c = np.correlate(group_data[ii], group_data[jj], "full")
+                c = c / samples_per_window
+                [_, pxx] = periodogram(c, fs=raw.info["sfreq"], window="hamming")
+                peak_powers.append(max(pxx))
 
-            scores[ii, window] = max(pxx)
-            scores[ii + 1, window] = max(pxx)
+            # Use the minimum value in the group as peak power
+            pp = min(peak_powers) if peak_powers else 0.0
 
-            if (threshold is not None) & (max(pxx) < threshold):
+            # Assign the same peak power value to all channels in the group
+            scores[ch_group, window] = pp
+
+            # Add BAD_PeakPower annotation to channels if below threshold
+            if (threshold is not None) & (pp < threshold):
                 raw.annotations.append(
                     t_start,
                     time_window,
                     "BAD_PeakPower",
-                    ch_names=[raw.ch_names[ii : ii + 2]],
+                    ch_names=[[raw.ch_names[ii] for ii in ch_group]],
                 )
-    scores = scores[np.argsort(picks)]
+
     return raw, scores, times

--- a/mne_nirs/preprocessing/_peak_power.py
+++ b/mne_nirs/preprocessing/_peak_power.py
@@ -78,9 +78,11 @@ def peak_power(
     # Note that peak_power currently does not require a specific data type (e.g. OD)
     _validate_type(raw, BaseRaw, "raw")
 
-    # `picks` returns a list of channels ordered alphanumerically and grouped by
-    # channel groups (i.e. same source-detector pair). The order of channels in
-    # `picks` can be differ from the order of channels in `raw`.
+    # `picks` returns a list of channels ordered alphanumerically, which may differ
+    # from the order of channels in `raw`. By virtue of being sorted, channels follow
+    # an ordered sequence of S-D pairs and wavelengths, e.g., S1_D1 760, S1_D1 850,
+    # S1_D2 760, S1_D2 850, S2_D1 760, S2_D1 850, etc. The algorithm below relies on
+    # this ordering.
     picks = _validate_nirs_info(raw.info)
 
     # Number of wavelengths extracted from channel names

--- a/mne_nirs/preprocessing/_scalp_coupling_segmented.py
+++ b/mne_nirs/preprocessing/_scalp_coupling_segmented.py
@@ -55,7 +55,7 @@ def scalp_coupling_index_windowed(
     Notes
     -----
     This implementation of scalp coupling index differs from Pollonini's
-    original[1]_[2]_, in that the original calculates scalp coupling index on raw
+    original [1]_ [2]_, in that the original calculates scalp coupling index on raw
     data, whereas optical density data is expected here; and while both
     implementations calculate a kind of cosine similarity, the mathematical
     details are different. Users are advised to check the results and adjust

--- a/mne_nirs/preprocessing/_scalp_coupling_segmented.py
+++ b/mne_nirs/preprocessing/_scalp_coupling_segmented.py
@@ -77,9 +77,11 @@ def scalp_coupling_index_windowed(
     _validate_type(raw, BaseRaw, "raw")
 
     # Pick optical density channels
-    # `picks` returns a list of channels ordered alphanumerically and grouped by
-    # channel groups (i.e. same source-detector pair). The order of channels in
-    # `picks` can be differ from the order of channels in `raw`.
+    # `picks` returns a list of channels ordered alphanumerically, which may differ
+    # from the order of channels in `raw`. By virtue of being sorted, channels follow
+    # an ordered sequence of S-D pairs and wavelengths, e.g., S1_D1 760, S1_D1 850,
+    # S1_D2 760, S1_D2 850, S2_D1 760, S2_D1 850, etc. The algorithm below relies on
+    # this ordering.
     picks = _validate_nirs_info(raw.info, fnirs="od", which="Scalp coupling index")
 
     # Number of wavelengths extracted from channel names

--- a/mne_nirs/preprocessing/_scalp_coupling_segmented.py
+++ b/mne_nirs/preprocessing/_scalp_coupling_segmented.py
@@ -52,13 +52,14 @@ def scalp_coupling_index_windowed(
     times : list
         List of the start and end times of each window used to compute SCI.
 
-    Warning
-    -------
-    This implementation of scalp coupling index differs from Pollonini's original in
-    that the original calculates scalp coupling index on raw data, whereas optical
-    density data is expected here; and while both implementations calculate a kind
-    of cosine similarity, the mathematical details are different. Users are advised
-    to check the results and adjust parameters as needed.
+    Notes
+    -----
+    This implementation of scalp coupling index differs from Pollonini's
+    original[1]_[2]_, in that the original calculates scalp coupling index on raw
+    data, whereas optical density data is expected here; and while both
+    implementations calculate a kind of cosine similarity, the mathematical
+    details are different. Users are advised to check the results and adjust
+    parameters as needed.
 
     References
     ----------

--- a/mne_nirs/preprocessing/_scalp_coupling_segmented.py
+++ b/mne_nirs/preprocessing/_scalp_coupling_segmented.py
@@ -5,7 +5,7 @@
 import numpy as np
 from mne.filter import filter_data
 from mne.io import BaseRaw
-from mne.preprocessing.nirs import _validate_nirs_info
+from mne.preprocessing.nirs import _channel_frequencies, _validate_nirs_info
 from mne.utils import _validate_type, verbose
 
 
@@ -21,7 +21,7 @@ def scalp_coupling_index_windowed(
     verbose=False,
 ):
     """
-    Compute scalp coupling index for each channel and time window.
+    Compute scalp coupling index (SCI) for each channel and time window.
 
     As described in [1]_ and [2]_.
     This method provides a metric of data quality along the duration of
@@ -46,12 +46,19 @@ def scalp_coupling_index_windowed(
     Returns
     -------
     raw : instance of Raw
-        The Raw data. Optionally annotated with bad segments.
+        Copy of the input raw data. Optionally annotated with bad segments.
     scores : array (n_nirs, n_windows)
-        Array of peak power values.
+        Array of SCI values.
     times : list
-        List of the start and end times of each window used to compute the
-        peak spectral power.
+        List of the start and end times of each window used to compute SCI.
+
+    Warning
+    -------
+    This implementation of scalp coupling index differs from Pollonini's original in
+    that the original calculates scalp coupling index on raw data, whereas optical
+    density data is expected here; and while both implementations calculate a kind
+    of cosine similarity, the mathematical details are different. Users are advised
+    to check the results and adjust parameters as needed.
 
     References
     ----------
@@ -62,11 +69,24 @@ def scalp_coupling_index_windowed(
            quality assessment of fNIRS scans." Optics and the Brain.
            Optical Society of America, 2020.
     """
+    # Make a copy of the data and ensure it's loaded into memory
     raw = raw.copy().load_data()
+
+    # Validate that the input contains raw fNIRS data
     _validate_type(raw, BaseRaw, "raw")
 
+    # Pick optical density channels
+    # `picks` returns a list of channels ordered alphanumerically and grouped by
+    # channel groups (i.e. same source-detector pair). The order of channels in
+    # `picks` can be differ from the order of channels in `raw`.
     picks = _validate_nirs_info(raw.info, fnirs="od", which="Scalp coupling index")
 
+    # Number of wavelengths extracted from channel names
+    n_wavelengths = len(np.unique(_channel_frequencies(raw.info)))
+
+    # Bandpass filter data to extract heartbeat-related frequencies
+    # Note: filtering is applied only to the selected channels (picks),
+    # with channel order preserved, regardless of how the picks are ordered.
     filtered_data = filter_data(
         raw._data,
         raw.info["sfreq"],
@@ -78,34 +98,53 @@ def scalp_coupling_index_windowed(
         h_trans_bandwidth=h_trans_bandwidth,
     )
 
+    # Length and number of windows
     window_samples = int(np.ceil(time_window * raw.info["sfreq"]))
     n_windows = int(np.floor(len(raw) / window_samples))
 
-    scores = np.zeros((len(picks), n_windows))
+    # Output variables
+    sci = np.zeros((len(picks), n_windows))
     times = []
 
     for window in range(n_windows):
         start_sample = int(window * window_samples)
-        end_sample = start_sample + window_samples
-        end_sample = np.min([end_sample, len(raw) - 1])
+        end_sample = np.min([start_sample + window_samples, len(raw) - 1])
 
         t_start = raw.times[start_sample]
         t_stop = raw.times[end_sample]
         times.append((t_start, t_stop))
 
-        for ii in range(0, len(picks), 2):
-            c1 = filtered_data[picks[ii]][start_sample:end_sample]
-            c2 = filtered_data[picks[ii + 1]][start_sample:end_sample]
-            c = np.corrcoef(c1, c2)[0][1]
-            scores[ii, window] = c
-            scores[ii + 1, window] = c
+        # pair indices for all channels pairs
+        pair_indices = np.triu_indices(n_wavelengths, k=1)
 
+        # iterate over channel groups defined by `picks`
+        for gg in range(0, len(picks), n_wavelengths):
+            ch_group = picks[gg : gg + n_wavelengths]
+            group_data = filtered_data[ch_group, start_sample:end_sample]
+
+            # Calculate pairwise correlations within the group
+            correlations = []
+            for ii, jj in zip(*pair_indices):
+                # `corrcoef` throws an error when the data has a near-0 std;
+                # with "ignore" set, it returns a NaN instead
+                with np.errstate(invalid="ignore"):
+                    c = np.corrcoef(group_data[ii], group_data[jj])[0][1]
+                if np.isfinite(c):
+                    correlations.append(c)
+
+            # Use the minimum correlation in the group as SCI
+            c = min(correlations) if correlations else 0.0
+
+            # Assign the same SCI value to all channels in the group
+            sci[ch_group, window] = c
+
+            # Add BAD_SCI annotation to channels if below threshold
             if (threshold is not None) & (c < threshold):
                 raw.annotations.append(
                     t_start,
                     time_window,
                     "BAD_SCI",
-                    ch_names=[raw.ch_names[ii : ii + 2]],
+                    ch_names=[[raw.ch_names[ii] for ii in ch_group]],
                 )
-    scores = scores[np.argsort(picks)]
-    return raw, scores, times
+
+    return raw, sci, times

--- a/mne_nirs/preprocessing/tests/test_quality.py
+++ b/mne_nirs/preprocessing/tests/test_quality.py
@@ -96,11 +96,9 @@ def find_annotations(
     return marks
 
 
-def fnirs_datasets(
-    fnirs_motor_data, fnirs_labnirs_3wl_data
-) -> list[mne.io.BaseRaw]:
+def fnirs_datasets(fnirs_motor_data, fnirs_labnirs_3wl_data) -> list[mne.io.BaseRaw]:
     if not datasets.has_dataset("testing"):
-         pytest.skip("Requires testing dataset")
+        pytest.skip("Requires testing dataset")
     return [fnirs_motor_data, fnirs_labnirs_3wl_data]
 
 

--- a/mne_nirs/preprocessing/tests/test_quality.py
+++ b/mne_nirs/preprocessing/tests/test_quality.py
@@ -21,10 +21,8 @@ def fixture_fnirs_motor_data() -> mne.io.BaseRaw:
     return mne.preprocessing.nirs.optical_density(raw)
 
 
-@pytest.fixture(name="fnirs_labnirs_3wl_data")
-def fixture_fnirs_labnirs_3wl_data() -> mne.io.BaseRaw:
+def fnirs_labnirs_3wl_data() -> mne.io.BaseRaw:
     """Read and return 3-wavelength testing data."""
-    pytest.importorskip("h5py")
     fname_labnirs_3wl = (
         mne.datasets.testing.data_path(download=False)
         / "SNIRF"
@@ -43,7 +41,7 @@ def fixture_fnirs_labnirs_3wl_data() -> mne.io.BaseRaw:
         "S1_D1 805",
         "S1_D1 830",
     ]
-    assert_array_equal(raw.ch_names[:9], ch_names)
+    assert raw.ch_names[:9] == ch_names
     return mne.preprocessing.nirs.optical_density(raw)
 
 
@@ -98,14 +96,14 @@ def find_annotations(
     return marks
 
 
-@pytest.fixture(name="fnirs_datasets")
-def fixture_fnirs_datasets(
+def fnirs_datasets(
     fnirs_motor_data, fnirs_labnirs_3wl_data
 ) -> list[mne.io.BaseRaw]:
+    if not datasets.has_dataset("testing"):
+         pytest.skip("Requires testing dataset")
     return [fnirs_motor_data, fnirs_labnirs_3wl_data]
 
 
-@mne.datasets.testing.requires_testing_data
 def test_peak_power_runs(fnirs_datasets: list[mne.io.BaseRaw]) -> None:
     """Test that `peak_power` successfully runs with test data."""
     for raw in fnirs_datasets:

--- a/mne_nirs/preprocessing/tests/test_quality.py
+++ b/mne_nirs/preprocessing/tests/test_quality.py
@@ -2,28 +2,551 @@
 #
 # License: BSD (3-clause)
 
-import os
+from pathlib import Path
 
-import mne
+import mne  # type: ignore
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
 
 from mne_nirs.preprocessing import peak_power, scalp_coupling_index_windowed
 
 
-def test_peak_power():
-    fnirs_data_folder = mne.datasets.fnirs_motor.data_path()
-    fnirs_raw_dir = os.path.join(fnirs_data_folder, "Participant-1")
-    raw = mne.io.read_raw_nirx(fnirs_raw_dir, verbose=True).load_data()
-    raw = mne.preprocessing.nirs.optical_density(raw)
+@pytest.fixture(name="fnirs_motor_data")
+def fixture_fnirs_motor_data() -> mne.io.BaseRaw:
+    """Read and return motor experiment data."""
+    fnirs_data_folder = Path(mne.datasets.fnirs_motor.data_path())
+    fnirs_raw_dir = fnirs_data_folder / "Participant-1"
+    raw = mne.io.read_raw_nirx(str(fnirs_raw_dir), verbose=True).load_data()
+    return mne.preprocessing.nirs.optical_density(raw)
 
-    raw, scores, times = peak_power(raw)
-    assert len(scores) == len(raw.ch_names)
+
+@pytest.fixture(name="fnirs_labnirs_3wl_data")
+def fixture_fnirs_labnirs_3wl_data() -> mne.io.BaseRaw:
+    """Read and return 3-wavelength testing data."""
+    pytest.importorskip("h5py")
+    fname_labnirs_3wl = (
+        mne.datasets.testing.data_path(download=False)
+        / "SNIRF"
+        / "Labnirs"
+        / "labnirs_3wl_raw_recording.snirf"
+    )
+    raw = mne.io.read_raw_snirf(fname_labnirs_3wl)
+    ch_names = [
+        "S2_D2 780",
+        "S2_D2 805",
+        "S2_D2 830",
+        "S1_D2 780",
+        "S1_D2 805",
+        "S1_D2 830",
+        "S1_D1 780",
+        "S1_D1 805",
+        "S1_D1 830",
+    ]
+    assert_array_equal(raw.ch_names[:9], ch_names)
+    return mne.preprocessing.nirs.optical_density(raw)
 
 
-def test_sci_windowed():
-    fnirs_data_folder = mne.datasets.fnirs_motor.data_path()
-    fnirs_raw_dir = os.path.join(fnirs_data_folder, "Participant-1")
-    raw = mne.io.read_raw_nirx(fnirs_raw_dir, verbose=True).load_data()
-    raw = mne.preprocessing.nirs.optical_density(raw)
+def find_annotations(
+    raw: mne.io.BaseRaw,
+    description: str,
+    windows: list[int],
+    channel_names: list[str],
+    window_time: float,
+) -> np.ndarray:
+    """Return a matrix of whether expected annotations are found in the expected places.
 
-    raw, scores, times = scalp_coupling_index_windowed(raw)
-    assert len(scores) == len(raw.ch_names)
+    Parameters
+    ----------
+    raw : instance of Raw
+        The Raw data, annotated (e.g. with BAD_SCI or BAD_PeakPower annotations)
+    description : str
+        The description of the annotation to look for (e.g. "BAD_SCI").
+    windows : list of int
+        The window numbers (starting from 0) to look for annotations in.
+    channel_names : list of str
+        The channel names to look for annotations in.
+    window_time : float
+        The duration of the window in seconds (e.g. 10), used to calculate the
+        expected annotation onset times.
+
+    Returns
+    -------
+    marks : array (n_channels, n_windows)
+        A boolean array where True indicates that an annotation with the specified
+        description was found for the corresponding channel and window.
+    """
+    marks = np.zeros((len(channel_names), len(windows)), dtype=bool)
+
+    for ann in raw.annotations:
+        # skip if not expected label
+        if ann["description"] != description:
+            continue
+
+        # find corresponding window
+        ann_window = round(ann["onset"] / window_time)  # type: ignore
+        try:
+            col = windows.index(ann_window)
+        except ValueError:
+            continue
+
+        # confirm channel name
+        for ann_name in ann["ch_names"]:  # type: ignore
+            if ann_name in channel_names:
+                marks[channel_names.index(ann_name), col] = True
+
+    return marks
+
+
+@pytest.fixture(name="fnirs_datasets")
+def fixture_fnirs_datasets(
+    fnirs_motor_data, fnirs_labnirs_3wl_data
+) -> list[mne.io.BaseRaw]:
+    return [fnirs_motor_data, fnirs_labnirs_3wl_data]
+
+
+@mne.datasets.testing.requires_testing_data
+def test_peak_power_runs(fnirs_datasets: list[mne.io.BaseRaw]) -> None:
+    """Test that `peak_power` successfully runs with test data."""
+    for raw in fnirs_datasets:
+        _, scores, _ = peak_power(raw.copy())
+        assert len(scores) == len(raw.ch_names)
+
+
+@mne.datasets.testing.requires_testing_data
+def test_sci_windowed_runs(fnirs_datasets: list[mne.io.BaseRaw]) -> None:
+    """Test that `scalp_coupling_index_windowed` successfully runs with test data."""
+    for raw in fnirs_datasets:
+        _, scores, _ = scalp_coupling_index_windowed(raw.copy())
+        assert len(scores) == len(raw.ch_names)
+
+
+def test_sci_windowed_known_values(fnirs_motor_data: mne.io.BaseRaw):
+    """Test segmented SCI with known correlation values for 2-wavelength data.
+
+    Three channel pairs are overwritten with synthetic data that produce
+    predictable scores. First, the channels are overwritten with the same
+    signal to achieve perfect correlation (and keep the number of bad marks
+    low). Then, various cases are tested in two, distant, 30-second windows
+    (235 samples at 7.8125 Hz):
+
+    - Pair 0 (ch 0-1): both = signal (SCI ≈ +1) throughout
+    - Pair 1 (ch 2-3): W1 scale-invariant (SCI ≈ +1), W2 ch1 = -signal (SCI ≈ -1).
+    - Pair 2 (ch 4-5): W1 noise + signal (SCI low), W2 noise + noise (SCI ≈ 0).
+
+    The scores, annotations, and whether they're associated with the correct
+    windows are confirmed.
+
+    For now, the test uses optical density data, even though SCI was meant
+    to be calculated on raw voltage measurement. In the future, when the
+    ``scalp_coupling_index_windowed`` method is updated to use raw data,
+    this test will need to be updated as well.
+    """
+    raw = fnirs_motor_data.copy()
+
+    sfreq = raw.info["sfreq"]
+    time_window = 30
+    num_channels = 6
+    windowA = 5
+    windowB = 11
+
+    rng = np.random.default_rng(seed=123456)
+
+    # time_window=30 -> window_samples=235, n_windows=98
+    w_numsamples = int(np.ceil(time_window * sfreq))
+    # window A start:end with 0.5 window buffer around it for filter leak
+    wA = round((windowA - 0.5) * w_numsamples), round((windowA + 1.5) * w_numsamples)
+    # windows B start:end with buffer
+    wB = round((windowB - 0.5) * w_numsamples), round((windowB + 1.5) * w_numsamples)
+
+    # write the same signal in all the used channels
+    signal = np.sin(2.0 * np.pi * np.arange(raw.n_times) / sfreq) - 0.5
+    raw._data[0:num_channels] = signal[np.newaxis, :].copy()
+
+    # Pair 0 (ch 0, 1)
+    # signal in both, SCI≈1 throughout and no annotations in either window
+
+    # Pair 1 (ch 2, 3):
+    # window A: scale invariant (SCI ≈ +1) vs base signal in channel 3
+    raw._data[2][wA[0] : wA[1]] = 0.3 * signal[wA[0] : wA[1]] + 2
+    # window B: anti-correlation (SCI ≈ -1) vs base signal in channel 2
+    raw._data[3][wB[0] : wB[1]] = -signal[wB[0] : wB[1]]
+
+    # Pair 2 (ch 4, 5):
+    # window A: noisy signal (low SCI) vs clean signal in channel 5
+    raw._data[4][wA[0] : wA[1]] = (
+        rng.normal(size=(wA[1] - wA[0],)) * 3.0 + signal[wA[0] : wA[1]]
+    ) / 4
+    # window B: both noise (SCI ≈ 0)
+    raw._data[4][wB[0] : wB[1]] = rng.normal(size=(wB[1] - wB[0],))
+    raw._data[5][wB[0] : wB[1]] = rng.random(size=(wB[1] - wB[0],)) - 0.5
+
+    # calculate SCI quality
+    raw, scores, times_out = scalp_coupling_index_windowed(
+        raw, time_window=time_window, threshold=0.7
+    )
+
+    # verify output shape
+    assert scores.shape == (len(raw.ch_names), 98)
+    assert len(times_out) == 98
+
+    # verify SCI scores
+    assert_allclose(scores[0:2, windowA], [1, 1], atol=0.05)  # pair 0
+    assert_allclose(scores[0:2, windowB], [1, 1], atol=0.05)
+    assert_allclose(scores[2:4, windowA], [1, 1], atol=0.05)  # pair 1, window A
+    assert_allclose(scores[2:4, windowB], [-1, -1], atol=0.05)  # pair 1, window B
+    assert_allclose(scores[4:6, windowA], [0.44, 0.44], atol=0.05)  # pair 2, window A
+    assert_allclose(
+        scores[4:6, windowB], [-0.0471, -0.0471], atol=0.01
+    )  # pair 2, window B
+
+    # verify that BAD_SCI annotations exist for expected channels/windows
+    marks = find_annotations(
+        raw, "BAD_SCI", [windowA, windowB], raw.ch_names[:num_channels], time_window
+    )
+
+    expected = np.array([False, False] * 2 + [False, True] * 2 + [True, True] * 2)
+    assert_array_equal(marks.ravel(), expected)
+
+
+@mne.datasets.testing.requires_testing_data
+def test_sci_windowed_known_values_multi_wavelength(
+    fnirs_labnirs_3wl_data: mne.io.BaseRaw,
+) -> None:
+    """Test segmented SCI with known correlation values for >=3-wavelength data.
+
+    This test focuses on multi-wavelength specific cases that were not covered
+    in the 2-wavelength test, using the labnirs 3-wavelength SNIRF recording
+    (250 samples at 19.6 Hz).
+
+    - Group 1 (ch 0-2): all the same signal (SCI ≈ +1)
+    - Group 2 (ch 3-5): one channel has inverted signal (SCI ≈ -1)
+    - Group 3 (ch 6-8): one channel has noisy signal, another just noise
+      (smallest SCI counts, SCI will be very small)
+    - Group 4 (ch 9-11): same as group 3, different order (same SCI)
+
+    For now, the test uses optical density data, even though SCI was meant
+    to be calculated on raw voltage measurement. In the future, when the
+    ``scalp_coupling_index_windowed`` method is updated to use raw data,
+    this test will need to be updated as well.
+    """
+    raw = fnirs_labnirs_3wl_data.copy()
+    sfreq = raw.info["sfreq"]
+
+    time_window = 4
+    num_channels = 12
+
+    rng = np.random.default_rng(seed=123456)
+
+    # write the same signal in all the used channels
+    signal = np.sin(2 * np.pi * 1.0 * np.arange(raw.n_times) / sfreq) - 0.5
+    # no need to use copy() for signal as the data is not modified later on
+    # if part of the data is overwritten (as in the 2-wl test), copy() is needed
+    raw._data[0:num_channels] = signal[np.newaxis, :]
+
+    # Group 1 (ch 0, 1, 2): all perfectly correlated
+
+    # Group 2 (ch 3, 4, 5): one channel has inverted signal
+    raw._data[4] = -signal
+
+    # Group 3 (ch 6, 7, 8): one channel is noisy, another just noise
+    rand1 = rng.random((raw.n_times,)) - 0.5
+    raw._data[6] = 0.1  # SCI = 0.09 if changed alone
+    raw._data[8] = rand1  #  SCI = -0.149 if alone
+
+    # Group 4 (ch 9, 10, 11): same as group 3 just different order
+    raw._data[10] = rand1
+    raw._data[11] = 0.1
+
+    # calculate SCI quality
+    raw, scores, times_out = scalp_coupling_index_windowed(
+        raw, time_window=time_window, threshold=0.7
+    )
+
+    # verify output shape
+    assert scores.shape == (len(raw.ch_names), 3)
+    assert len(times_out) == 3
+
+    # verify SCI scores (in the 2nd, middle window)
+    assert_allclose(scores[0:3, 1], 1, atol=0.05)  # group 1
+    assert_allclose(scores[3:6, 1], -1, atol=0.05)  # group 2
+    assert_allclose(scores[6:9, 1], -0.149, atol=0.01)  # group 3
+    assert_allclose(scores[9:12, 1], scores[6:9, 1], atol=0.01)  # group 4
+
+    # verify that BAD_SCI annotations exist for expected channels
+    marks = find_annotations(
+        raw, "BAD_SCI", [1], raw.ch_names[:num_channels], time_window
+    )
+
+    expected = np.repeat([False, True, True, True], 3)
+    assert_array_equal(marks.ravel(), expected)
+
+
+def test_peak_power_known_values(fnirs_motor_data: mne.io.BaseRaw) -> None:
+    """Test segmented PP with known spectral properties for 2-wavelength data.
+
+    First, test channels are overwritten with a sinusoid wave. Then, test data
+    with known PP scores is written in two, distant, 30-second windows in the
+    same test channels (time_window=30 s, 235 samples/window at
+    7.8125 Hz):
+
+    - Pair 0 (ch 0-1): W1 both sinusoid (high PP), W2 scale (invariant, high)
+    - Pair 1 (ch 2-3): W1 phase shift, W2 inverted (invariant, both high PP)
+    - Pair 2 (ch 4-5): W1 other frequences (high PP), W2 noisy (lower PP)
+    - Pair 3 (ch 6-7): W1 only noise, W2 only other frequencies (both PP ≈ 0)
+
+    The scores, annotations, and whether they're associated with the correct
+    windows are confirmed.
+
+    For now, the test uses optical density data, even though PP was meant
+    to be calculated on raw voltage measurement. In the future, when the
+    tested method is updated to use raw data, this test will need to be
+    updated as well.
+    """
+    raw = fnirs_motor_data.copy()
+    sfreq = raw.info["sfreq"]
+
+    time_window = 30
+    num_channels = 8
+    windowA = 5
+    windowB = 11
+
+    rng = np.random.default_rng(seed=123456)
+
+    # time_window=30 -> window_samples=235, n_windows=98
+    w_numsamples = int(np.ceil(time_window * sfreq))
+    # window A start:end with 0.5 window buffer around it for filter leak
+    wA = round((windowA - 0.5) * w_numsamples), round((windowA + 1.5) * w_numsamples)
+    # windows B start:end with buffer
+    wB = round((windowB - 0.5) * w_numsamples), round((windowB + 1.5) * w_numsamples)
+
+    t = np.arange(raw.n_times) / sfreq
+    signal = np.sin(2 * np.pi * 1.0 * t) - 0.5  # base "heartbeat", 1 Hz
+    lf_signal = np.sin(2 * np.pi * 0.2 * t) - 0.5  # low-freq, 0.2 Hz
+    hf_signal = np.sin(2 * np.pi * 2.0 * t) - 0.5  # high-freq, 2 Hz
+
+    # write base sinusoid signal into all test channels
+    raw._data[0:num_channels] = signal[np.newaxis, :].copy()
+
+    # Pair 0 (ch 0, 1):
+    # window A: base signals (perfect PP)
+    # window B: scale invariant (perfect PP)
+    # test data in one channel is tested against base signal in the other
+    raw._data[1][wB[0] : wB[1]] = 0.3 * signal[wB[0] : wB[1]] + 2
+
+    # Pair 1 (ch 2, 3):
+    # window A: phase invariant (perfect PP)
+    raw._data[2][wA[0] : wA[1]] = signal[wA[0] + 2 : wA[1] + 2]
+    # window B: inverted signal (same as phase shift, perfect PP)
+    raw._data[3][wB[0] : wB[1]] = -signal[wB[0] : wB[1]]
+
+    # Pair 2 (ch 4, 5):
+    # window A: other freqs are filtered out (perfect PP)
+    raw._data[4][wA[0] : wA[1]] = (signal + lf_signal + hf_signal)[wA[0] : wA[1]]
+    # window B: noisy signal (lower PP)
+    raw._data[5][wB[0] : wB[1]] = (
+        rng.normal(size=(wB[1] - wB[0],)) * 2 + signal[wB[0] : wB[1]]
+    )
+
+    # Pair 3 (ch 6, 7):
+    # window A: only noise (PP ≈ 0)
+    raw._data[6][wA[0] : wA[1]] = rng.normal(size=(wB[1] - wB[0],))
+    # window B: only other frequencies (PP ≈ 0)
+    raw._data[7][wB[0] : wB[1]] = lf_signal[wB[0] : wB[1]] + hf_signal[wB[0] : wB[1]]
+
+    # calculate PP quality
+    raw, scores, times_out = peak_power(raw, time_window=time_window, threshold=0.1)
+
+    # verify output shape
+    assert scores.shape == (len(raw.ch_names), 98)
+    assert len(times_out) == 98
+
+    # verify scores
+    assert_allclose(scores[0:4, [windowA, windowB]], 10, atol=0.05)  # pairs 0 and 1
+    assert_allclose(scores[4:6, windowA], [10, 10], atol=0.05)  # pair 2, window A
+    assert_allclose(scores[4:6, windowB], [3.5, 3.5], atol=0.05)  # pair 2, window B
+    assert_allclose(scores[6:8, windowA], [0, 0], atol=0.05)  # pair 3, window A
+    assert_allclose(scores[6:8, windowB], [0, 0], atol=0.05)  # pair 3, window B
+
+    # verify that BAD_PeakPower annotations exist for expected channels/windows
+    marks = find_annotations(
+        raw,
+        "BAD_PeakPower",
+        [windowA, windowB],
+        raw.ch_names[:num_channels],
+        time_window,
+    )
+
+    expected = np.array([False, False] * 6 + [True, True] * 2)
+    assert_array_equal(marks.ravel(), expected)
+
+
+@mne.datasets.testing.requires_testing_data
+def test_peak_power_known_values_multi_wavelength(
+    fnirs_labnirs_3wl_data: mne.io.BaseRaw,
+) -> None:
+    """Test segmented PP with known spectral properties for >=3-wavelength data.
+
+    This test focuses on multi-wavelength specific cases that were not covered
+    in the 2-wavelength test, using the labnirs 3-wavelength SNIRF recording
+    (250 samples at 19.6 Hz). The recording is long enough for three 4-second
+    windows, of which the tests are evaluated in the middle one.
+
+    - Group 1 (ch 0-2): in-band sinusoid throughout (perfect PP)
+    - Group 2 (ch 3-5): signal + noisy signal + noise (smallest wins, PP≈0)
+    - Group 3 (ch 6-8): group 2 with different order (same PP)
+    """
+    raw = fnirs_labnirs_3wl_data.copy().load_data()
+
+    sfreq = raw.info["sfreq"]
+    time_window = 4
+    num_channels = 9
+    rng = np.random.default_rng(seed=123456)
+    t = np.arange(raw.n_times) / sfreq
+    signal = np.sin(2 * np.pi * 1.0 * t)  # base "heartbeat", 1 Hz
+    noheart = np.sin(2 * np.pi * 0.1 * t) + np.sin(
+        2 * np.pi * 3 * t
+    )  # 0.1 Hz + 3 Hz, not in the 0.5-2.5 Hz PP band
+    noisy = signal + rng.normal(size=(raw.n_times,)) * 2
+
+    # write the same signal in all the used channels
+    # No need to use copy() for signal as the data is not modified later on.
+    # If part of the data were overwritten (as in the 2-wl test),
+    # copy() would be needed.
+    raw._data[0:num_channels] = signal[np.newaxis, :]
+
+    # Group 1 (S2-D2): all perfectly correlated, no need to change
+
+    # Group 2 (S1-D2):
+    # base signal, noisy signal, no heart signal, should have very low PP
+    raw._data[4] = noisy.copy()
+    raw._data[5] = noheart.copy()
+
+    # Group 3 (S1-D1): group 2 reordered, should have same-ish PP
+    # It won't be exactly the same value as the result of the correlation
+    # will be reversed if the compared channels are reversed, which results
+    # in minimally different periodograms.
+    raw._data[6] = noheart.copy()
+    raw._data[8] = noisy.copy()
+
+    # calculate PP quality
+    raw, scores, times_out = peak_power(raw, time_window=time_window, threshold=0.1)
+
+    # verify output shape
+    assert scores.shape == (len(raw.ch_names), 3)
+    assert len(times_out) == 3
+
+    # verify scores
+    print(scores[:9, 1])
+    from pprint import pprint
+
+    print(raw.ch_names[:9])
+    pprint([ann for ann in raw.annotations if ann["description"] == "BAD_PeakPower"])
+    assert_allclose(scores[0:3, 1], 1.34, atol=0.01)  # group 0
+    assert_allclose(scores[3:9, 1], 0.03, atol=0.01)  # groups 2 and 3
+    assert_allclose(
+        scores[3:6, 1], scores[6:9, 1], atol=0.01
+    )  # groups 2 and 3 should be about the same
+
+    # verify that BAD_PeakPower annotations exist for groups 2 and 3 in the 2nd window
+    marks = find_annotations(
+        raw,
+        "BAD_PeakPower",
+        [1],
+        raw.ch_names[:num_channels],
+        time_window,
+    )
+
+    expected = np.array([False] * 3 + [True] * 6)
+    assert_array_equal(marks.ravel(), expected)
+
+
+def test_sci_windowed_annotations_target_correct_channels() -> None:
+    """Test that BAD_SCI annotations are assigned to the correct channels.
+
+    _validate_nirs_info / _check_channels_ordered returns picks sorted
+    alphabetically by channel name, which can differ from the row order
+    in raw._data. This test verifies that annotations are added to the
+    correct channels regardless of the order of the channel names.
+    """
+    sfreq = 10.0
+    n_samples = 400  # 40 s at 10 Hz → 4 windows of 10 s
+
+    # Channels (both wavelengths and S-D numbers) stored in NON-alphabetical order
+    ch_names = [
+        "S2_D1 760",
+        "S1_D1 850",
+        "S1_D1 760",
+        "S2_D1 850",
+    ]
+    ch_types = ["fnirs_od"] * 4
+
+    info = mne.create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types)
+    for ch in info["chs"]:
+        # Wavelength must be stored in loc[9] (required by _validate_nirs_info).
+        ch["loc"][9] = float(ch["ch_name"].split(" ")[1])
+
+    rng = np.random.default_rng(0)
+    signal = rng.standard_normal(n_samples)
+
+    # S1_D1 (raw._data rows 2, 1): identical  → SCI = +1.0  (GOOD, above threshold)
+    # S2_D1 (raw._data rows 0, 3): anti-corr  → SCI = −1.0  (BAD,  below threshold)
+    data = np.array([signal, signal, signal, -signal], dtype=float)
+
+    raw = mne.io.RawArray(data, info)
+    raw_out, _, _ = scalp_coupling_index_windowed(raw, time_window=10, threshold=0.7)
+
+    bad_annotations = [
+        ann for ann in raw_out.annotations if ann["description"] == "BAD_SCI"
+    ]
+    bad_channels = {ann["ch_names"] for ann in bad_annotations}
+    assert bad_channels == {("S2_D1 760", "S2_D1 850")}, (
+        "BAD_SCI annotations were assigned to the wrong channels."
+    )
+
+
+def test_pp_windowed_annotations_target_correct_channels() -> None:
+    """Test that BAD_PeakPower annotations are assigned to the correct channels.
+
+    _validate_nirs_info / _check_channels_ordered returns picks sorted
+    alphabetically by channel name, which can differ from the row order
+    in raw._data. This test verifies that annotations are added to the
+    correct channels regardless of the order of the channel names.
+    """
+    sfreq = 10.0
+    n_samples = 400  # 40 s at 10 Hz → 4 windows of 10 s
+
+    # Channels (both wavelengths and S-D numbers) stored in NON-alphabetical order
+    ch_names = [
+        "S2_D1 760",
+        "S1_D1 850",
+        "S1_D1 760",
+        "S2_D1 850",
+    ]
+    ch_types = ["fnirs_od"] * 4
+
+    info = mne.create_info(ch_names=ch_names, sfreq=sfreq, ch_types=ch_types)
+    for ch in info["chs"]:
+        # Wavelength must be stored in loc[9] (required by _validate_nirs_info).
+        ch["loc"][9] = float(ch["ch_name"].split(" ")[1])
+
+    t = np.arange(n_samples) / sfreq
+    signal = np.sin(2 * np.pi * 1.0 * t)  # base "heartbeat", 1 Hz
+    noheart = np.sin(2 * np.pi * 0.1 * t) + np.sin(
+        2 * np.pi * 3 * t
+    )  # 0.1 Hz + 3 Hz, not in the 0.5-2.5 Hz PP band
+
+    # S1_D1 (raw._data rows 2, 1): identical  → high PP  (GOOD, above threshold)
+    # S2_D1 (raw._data rows 0, 3): no heartbeat  → low PP  (BAD,  below threshold)
+    data = np.array([signal, signal, signal, noheart], dtype=float)
+
+    raw = mne.io.RawArray(data, info)
+    raw_out, _, _ = peak_power(raw, time_window=10, threshold=0.1)
+
+    bad_annotations = [
+        ann for ann in raw_out.annotations if ann["description"] == "BAD_PeakPower"
+    ]
+    bad_channels = {ann["ch_names"] for ann in bad_annotations}
+    assert bad_channels == {("S2_D1 760", "S2_D1 850")}, (
+        "BAD_PeakPower annotations were assigned to the wrong channels."
+    )

--- a/mne_nirs/preprocessing/tests/test_quality.py
+++ b/mne_nirs/preprocessing/tests/test_quality.py
@@ -21,8 +21,11 @@ def fixture_fnirs_motor_data() -> mne.io.BaseRaw:
     return mne.preprocessing.nirs.optical_density(raw)
 
 
-def fnirs_labnirs_3wl_data() -> mne.io.BaseRaw:
+@pytest.fixture(name="fnirs_labnirs_3wl_data")
+def fixture_fnirs_labnirs_3wl_data() -> mne.io.BaseRaw:
     """Read and return 3-wavelength testing data."""
+    if not mne.datasets.has_dataset("testing"):
+        pytest.skip("Requires testing dataset")
     fname_labnirs_3wl = (
         mne.datasets.testing.data_path(download=False)
         / "SNIRF"
@@ -96,9 +99,10 @@ def find_annotations(
     return marks
 
 
-def fnirs_datasets(fnirs_motor_data, fnirs_labnirs_3wl_data) -> list[mne.io.BaseRaw]:
-    if not datasets.has_dataset("testing"):
-        pytest.skip("Requires testing dataset")
+@pytest.fixture(name="fnirs_datasets")
+def fixture_fnirs_datasets(
+    fnirs_motor_data, fnirs_labnirs_3wl_data
+) -> list[mne.io.BaseRaw]:
     return [fnirs_motor_data, fnirs_labnirs_3wl_data]
 
 
@@ -109,7 +113,6 @@ def test_peak_power_runs(fnirs_datasets: list[mne.io.BaseRaw]) -> None:
         assert len(scores) == len(raw.ch_names)
 
 
-@mne.datasets.testing.requires_testing_data
 def test_sci_windowed_runs(fnirs_datasets: list[mne.io.BaseRaw]) -> None:
     """Test that `scalp_coupling_index_windowed` successfully runs with test data."""
     for raw in fnirs_datasets:
@@ -205,7 +208,6 @@ def test_sci_windowed_known_values(fnirs_motor_data: mne.io.BaseRaw):
     assert_array_equal(marks.ravel(), expected)
 
 
-@mne.datasets.testing.requires_testing_data
 def test_sci_windowed_known_values_multi_wavelength(
     fnirs_labnirs_3wl_data: mne.io.BaseRaw,
 ) -> None:
@@ -377,7 +379,6 @@ def test_peak_power_known_values(fnirs_motor_data: mne.io.BaseRaw) -> None:
     assert_array_equal(marks.ravel(), expected)
 
 
-@mne.datasets.testing.requires_testing_data
 def test_peak_power_known_values_multi_wavelength(
     fnirs_labnirs_3wl_data: mne.io.BaseRaw,
 ) -> None:

--- a/mne_nirs/preprocessing/tests/test_quality.py
+++ b/mne_nirs/preprocessing/tests/test_quality.py
@@ -99,25 +99,25 @@ def find_annotations(
     return marks
 
 
-@pytest.fixture(name="fnirs_datasets")
-def fixture_fnirs_datasets(
-    fnirs_motor_data, fnirs_labnirs_3wl_data
-) -> list[mne.io.BaseRaw]:
-    return [fnirs_motor_data, fnirs_labnirs_3wl_data]
+@pytest.fixture(
+    name="fnirs_dataset",
+    params=["fnirs_motor_data", "fnirs_labnirs_3wl_data"],
+)
+def fixture_fnirs_dataset(request) -> mne.io.BaseRaw:
+    """Each dataset becomes a separate parametrized test instance."""
+    return request.getfixturevalue(request.param)
 
 
-def test_peak_power_runs(fnirs_datasets: list[mne.io.BaseRaw]) -> None:
+def test_peak_power_runs(fnirs_dataset: mne.io.BaseRaw) -> None:
     """Test that `peak_power` successfully runs with test data."""
-    for raw in fnirs_datasets:
-        _, scores, _ = peak_power(raw.copy())
-        assert len(scores) == len(raw.ch_names)
+    _, scores, _ = peak_power(fnirs_dataset.copy())
+    assert len(scores) == len(fnirs_dataset.ch_names)
 
 
-def test_sci_windowed_runs(fnirs_datasets: list[mne.io.BaseRaw]) -> None:
+def test_sci_windowed_runs(fnirs_dataset: mne.io.BaseRaw) -> None:
     """Test that `scalp_coupling_index_windowed` successfully runs with test data."""
-    for raw in fnirs_datasets:
-        _, scores, _ = scalp_coupling_index_windowed(raw.copy())
-        assert len(scores) == len(raw.ch_names)
+    _, scores, _ = scalp_coupling_index_windowed(fnirs_dataset.copy())
+    assert len(scores) == len(fnirs_dataset.ch_names)
 
 
 def test_sci_windowed_known_values(fnirs_motor_data: mne.io.BaseRaw):

--- a/mne_nirs/visualisation/_plot_3d_montage.py
+++ b/mne_nirs/visualisation/_plot_3d_montage.py
@@ -101,7 +101,17 @@ def plot_3d_montage(
     _validate_type(view_map, dict, "views")
     _validate_type(src_det_names, (None, dict, str), "src_det_names")
     _validate_type(ch_names, (dict, str, None), "ch_names")
-    info = pick_info(info, pick_types(info, fnirs=True, exclude=())[::2])
+
+    # Filter to fNIRS data, and select one channel per source-detector pair.
+    # This method should work regardless of the ordering of channels in the info,
+    # and regardless of the number of members (e.g. number of wavelengths)
+    # for each source-detector pair. Channel names must be separated from the
+    # member designator (e.g. wavelength, HbO/HbR) by a space.
+    picks = pick_types(info, fnirs=True, exclude=())
+    prefixes = [info["ch_names"][p].split()[0] for p in picks]
+    _, first_idx = np.unique(prefixes, return_index=True)
+    info = pick_info(info, picks[first_idx])
+
     if isinstance(ch_names, str):
         _check_option("ch_names", ch_names, ("numbered",), extra="when str")
         ch_names = {


### PR DESCRIPTION
## Summary

Adds multi-wavelength (≥2) support to `scalp_coupling_index_windowed`,
`peak_power`, and `plot_3d_montage`, following the approach established in
mne-tools/mne-python#13408. Also fixes two bugs in the preprocessing functions
and one in the visualisation function that assumed a specific channel ordering,
which does not hold in general.

Closes #631.

## Changes

### `mne_nirs/preprocessing/_scalp_coupling_segmented.py` (ENH + FIX)

- The function previously hard-coded 2-wavelength pair selection using `[::2]` /
  `[1::2]` index strides. It now uses `_channel_frequencies` (imported from
  `mne.preprocessing.nirs`) to determine the number of distinct wavelengths, and
  iterates over channel groups of that size.
- For `n_wavelengths > 2`, all pairwise correlations within the group are computed
  and the **minimum** is used as the SCI score — matching the mne-python approach.
- **Bug fix:** Bad-channel annotations (`BAD_SCI`) were previously assigned using
  sequential indices (0, 1, 2, …) rather than the actual channel indices returned
  by `_validate_nirs_info`. Because `picks` can be in a different order than
  `raw.ch_names`, this caused annotations to be attached to the wrong channels
  when channel order was non-alphabetical (as is common in practice with NIRx and
  Shimadzu data).

### `mne_nirs/preprocessing/_peak_power.py` (ENH + FIX)

- Same multi-wavelength generalisation as SCI: `_channel_frequencies`-based group
  size, pairwise cross-correlation + periodogram, **minimum** peak power per group.
- **Bug fix:** Same incorrect annotation assignment as SCI — fixed identically.

### `mne_nirs/visualisation/_plot_3d_montage.py` (FIX)

- The function selected one representative channel per source-detector pair using
  `picks[::2]`, hard-coding a stride of 2. This broke with ≥3 wavelengths and with
  any dataset where channels were not in the expected interleaved order.
- Fixed by using `np.unique(prefixes, return_index=True)` to select the first
  occurrence of each unique source-detector prefix, independent of stride and order.

### `mne_nirs/preprocessing/tests/test_quality.py`

- Added `fnirs_labnirs_3wl_data` fixture backed by the Shimadzu Labnirs 3-wavelength
  SNIRF file now available in `mne-testing-data`.
- Added `test_sci_windowed_known_values_multi_wavelength` and
  `test_peak_power_known_values_multi_wavelength` — synthetic known-value tests for
  3-wavelength data covering correct score computation and annotation placement.
- Added `test_sci_windowed_annotations_target_correct_channels` and
  `test_pp_windowed_annotations_target_correct_channels` — regression tests that
  construct a minimal 4-channel dataset with non-alphabetical channel order and
  verify that bad annotations target the correct channels.

## Notes

- The algorithmic differences from Pollonini's original (signal type, window
  length, threshold defaults, cosine similarity vs. Pearson correlation) noted in
  #631 are **out of scope** for this PR.
- Same goes for tests for expected behaviour of SCI and PP measures
  (e.g. scale invariability).
- The 3-wavelength test data requires `mne-testing-data`; tests are guarded with
  `@mne.datasets.testing.requires_testing_data`.