### PR TITLE
docs: swap red/green in Filter Neural Signal tutorial comment

### DIFF
--- a/examples/general/plot_30_frequency.py
+++ b/examples/general/plot_30_frequency.py
@@ -236,7 +236,7 @@ fig.axes[0].set_title("")
 # ---------------------------------------------------------------------
 #
 # The effect of filtering on the neural signal is demonstrated below.
-# The green line illustrates the signal before filtering, and the red line
+# The red line illustrates the signal before filtering, and the green line
 # shows the signal after filtering.
 
 fig = raw_haemo.compute_psd(fmax=2).plot(


### PR DESCRIPTION
Closes #682.

The prose above the PSD plot in the *Filter Neural Signal* section of `examples/general/plot_30_frequency.py` claims the green line is before filtering and the red line is after. The code block immediately below plots the opposite order:

```python
fig = raw_haemo.compute_psd(fmax=2).plot(..., color="r", ...)   # before filter
raw_haemo = raw_haemo.filter(l_freq=None, h_freq=0.4, ...)
raw_haemo.compute_psd(fmax=2).plot(..., color="g", ...)         # after filter
```

So red corresponds to the pre-filter PSD and green to the post-filter PSD, which matches the screenshot in the issue. Flip the comment to match the figure (and the code).

## Testing

- Prose-only change in a Sphinx-gallery `.py` example.
- `python -m py_compile examples/general/plot_30_frequency.py` clean.
- No behaviour change.